### PR TITLE
Smmu v2

### DIFF
--- a/libsel4arm-vmm/include/sel4arm-vmm/devices.h
+++ b/libsel4arm-vmm/include/sel4arm-vmm/devices.h
@@ -13,9 +13,13 @@
 
 #include <stdint.h>
 
+#include <autoconf.h>
+
 #include <sel4arm-vmm/fault.h>
 #include <platsupport/gpio.h>
 #include <platsupport/plat/clock.h>
+
+#define NO_STREAM_ID 0
 
 typedef struct vm vm_t;
 
@@ -56,7 +60,10 @@ struct device {
     seL4_Word pstart;
 /// Device mapping size */
     seL4_Word size;
-
+#ifdef CONFIG_ARM_SMMU_V2
+/// Stream ID */
+    uint16_t sid;
+#endif
 /// Fault handler */
     int (*handle_page_fault)(struct device *d, vm_t *vm, fault_t *fault);
 /// device emulation private data */

--- a/libsel4arm-vmm/src/guest_vspace.c
+++ b/libsel4arm-vmm/src/guest_vspace.c
@@ -32,7 +32,7 @@ typedef struct guest_vspace {
     /* debug flag for checking if we add io spaces late */
     int done_mapping;
     int num_iospaces;
-    guest_iospace_t **iospaces;
+    guest_iospace_t *iospaces;
 #endif
 } guest_vspace_t;
 
@@ -125,12 +125,10 @@ int vmm_guest_vspace_add_iospace(vspace_t *loader, vspace_t *vspace, seL4_CPtr i
 
     assert(!guest_vspace->done_mapping);
 
-    guest_vspace->iospaces = realloc(guest_vspace->iospaces, sizeof(guest_iospace_t *) * (guest_vspace->num_iospaces + 1));
+    guest_vspace->iospaces = realloc(guest_vspace->iospaces, sizeof(guest_iospace_t) * (guest_vspace->num_iospaces + 1));
     assert(guest_vspace->iospaces);
-    guest_vspace->iospaces[guest_vspace->num_iospaces] = calloc(1, sizeof(guest_iospace_t));
-    assert(guest_vspace->iospaces[guest_vspace->num_iospaces]);
 
-    guest_iospace_t *guest_iospace = guest_vspace->iospaces[guest_vspace->num_iospaces];
+    guest_iospace_t *guest_iospace = &guest_vspace->iospaces[guest_vspace->num_iospaces];
     guest_iospace->iospace = iospace;
     int error = sel4utils_get_vspace(loader, &guest_iospace->iospace_vspace, &guest_iospace->iospace_vspace_data,
                                      guest_vspace->vspace_data.vka, seL4_CapNull, NULL, NULL);

--- a/libsel4arm-vmm/src/guest_vspace.c
+++ b/libsel4arm-vmm/src/guest_vspace.c
@@ -9,6 +9,8 @@
  *
  * @TAG(DATA61_BSD)
  */
+#include <autoconf.h>
+
 #include "sel4arm-vmm/guest_vspace.h"
 #include <sel4utils/vspace.h>
 #include <sel4utils/vspace_internal.h>
@@ -44,42 +46,48 @@ static int guest_vspace_map(vspace_t *vspace, seL4_CPtr cap, void *vaddr, seL4_C
         return error;
     }
 #ifdef CONFIG_ARM_SMMU
-    struct sel4utils_alloc_data *data = get_alloc_data(vspace);
-    /* this type cast works because the alloc data was at the start of the struct
-     * so it has the same address.
-     * This conversion is guaranteed to work by the C standard */
-    guest_vspace_t *guest_vspace = (guest_vspace_t *) data;
-    /* set the mapping bit */
-    guest_vspace->done_mapping = 1;
-    cspacepath_t orig_path;
-    vka_cspace_make_path(guest_vspace->vspace_data.vka, cap, &orig_path);
-    /* map into all the io spaces */
-    for (int i = 0; i < guest_vspace->num_iospaces; i++) {
-        cspacepath_t new_path;
-        error = vka_cspace_alloc_path(guest_vspace->vspace_data.vka, &new_path);
-        if (error) {
-            ZF_LOGE("Failed to allocate cslot to duplicate frame cap");
-            return error;
-        }
-        error = vka_cnode_copy(&new_path, &orig_path, seL4_AllRights);
+    /* If an object doesn't have Read or Write access, there isn't a reason to put
+     * it in DMA space
+     */
+    if (rights.words[0] != seL4_NoRights.words[0]) {
+        struct sel4utils_alloc_data *data = get_alloc_data(vspace);
+        /* this type cast works because the alloc data was at the start of the struct
+         * so it has the same address.
+         * This conversion is guaranteed to work by the C standard */
+        guest_vspace_t *guest_vspace = (guest_vspace_t*) data;
+        /* set the mapping bit */
+        guest_vspace->done_mapping = 1;
+        cspacepath_t orig_path;
+        vka_cspace_make_path(guest_vspace->vspace_data.vka, cap, &orig_path);
+        /* map into all the io spaces */
+        for (int i = 0; i < guest_vspace->num_iospaces; i++) {
+            cspacepath_t new_path;
+            error = vka_cspace_alloc_path(guest_vspace->vspace_data.vka, &new_path);
+            if (error) {
+                ZF_LOGE("Failed to allocate cslot to duplicate frame cap");
+                return error;
+            }
+            error = vka_cnode_copy(&new_path, &orig_path, seL4_AllRights);
 
-        guest_iospace_t *guest_iospace = guest_vspace->iospaces[i];
+            guest_iospace_t *guest_iospace = &guest_vspace->iospaces[i];
 
-        assert(error == seL4_NoError);
-        error = sel4utils_map_iospace_page(guest_vspace->vspace_data.vka, guest_iospace->iospace,
-                                           new_path.capPtr, (uintptr_t)vaddr, rights, 1,
-                                           size_bits, NULL, NULL);
-        if (error) {
-            ZF_LOGE("Failed to map page into iospace %d", i);
-            return error;
-        }
 
-        /* Store the slot of the frame cap copy in a vspace so they can be looked up and
-         * freed when this address gets unmapped. */
-        error = update_entries(&guest_iospace->iospace_vspace, (uintptr_t)vaddr, new_path.capPtr, size_bits, 0 /* cookie */);
-        if (error) {
-            ZF_LOGE("Failed to add iospace mapping information");
-            return error;
+            assert(error == seL4_NoError);
+            error = sel4utils_map_iospace_page(guest_vspace->vspace_data.vka, guest_iospace->iospace,
+                                               new_path.capPtr, (uintptr_t)vaddr, rights, 1,
+                                               size_bits, NULL, NULL);
+            if (error) {
+                ZF_LOGE("Failed to map page into iospace %d", i);
+                return error;
+            }
+
+            /* Store the slot of the frame cap copy in a vspace so they can be looked up and
+             * freed when this address gets unmapped. */
+            error = update_entries(&guest_iospace->iospace_vspace, (uintptr_t)vaddr, new_path.capPtr, size_bits, 0 /* cookie */);
+            if (error) {
+                ZF_LOGE("Failed to add iospace mapping information");
+                return error;
+            }
         }
     }
 #endif


### PR DESCRIPTION
These commits add support for the smmuv2. They add stream id to devices if smmu_v2 is defined, only add pages to iospaces if they r/w access, make the iospaces a single pointer. 

This PR also makes the guest iospaces a single pointer like the x86 vmm library. For whatever reason, the iospace pointer was causing issues with the rest of the vmm structure, and things weren't working.