### PR TITLE
Unaligned PCI BAR address fix

### DIFF
--- a/libsel4vm/docs/libsel4vm_guest_memory.md
+++ b/libsel4vm/docs/libsel4vm_guest_memory.md
@@ -59,7 +59,7 @@ Reserve a region of the VM's memory at a given base address
 
 Back to [interface description](#module-guest_memoryh).
 
-### Function `vm_reserve_anon_memory(vm, size, fault_callback, cookie, addr)`
+### Function `vm_reserve_anon_memory(vm, size, align, fault_callback, cookie, addr)`
 
 Reserve an anonymous region of the VM's memory. This uses memory previously made anonymous
 through the `vm_memory_make_anon` function.
@@ -68,6 +68,7 @@ through the `vm_memory_make_anon` function.
 
 - `vm {vm_t *}`: A handle to the VM
 - `size {size_t}`: Size of the anoymous emory region being reserved
+- `align {size_t}`: Requested alignment of the memory region
 - `fault_callback {memory_fault_callback_fn}`: Callback function that will be invoked if memory region is faulted on
 - `cookie {void *}`: User cookie to pass onto to callback
 - `addr {uintptr_t *}`: Pointer that will be set with the base address of the reserved anonymous region

--- a/libsel4vm/include/sel4vm/guest_memory.h
+++ b/libsel4vm/include/sel4vm/guest_memory.h
@@ -88,17 +88,18 @@ vm_memory_reservation_t *vm_reserve_memory_at(vm_t *vm, uintptr_t addr, size_t s
                                               memory_fault_callback_fn fault_callback, void *cookie);
 
 /***
- * @function vm_reserve_anon_memory(vm, size, fault_callback, cookie, addr)
+ * @function vm_reserve_anon_memory(vm, size, align, fault_callback, cookie, addr)
  * Reserve an anonymous region of the VM's memory. This uses memory previously made anonymous
  * through the `vm_memory_make_anon` function.
  * @param {vm_t *} vm                                       A handle to the VM
  * @param {size_t} size                                     Size of the anoymous emory region being reserved
+ * @param {size_t} align                                    Requested alignment of the memory region
  * @param {memory_fault_callback_fn} fault_callback         Callback function that will be invoked if memory region is faulted on
  * @param {void *} cookie                                   User cookie to pass onto to callback
  * @param {uintptr_t *} addr                                Pointer that will be set with the base address of the reserved anonymous region
  * @return                                                  NULL on failure otherwise a pointer to a reservation object representing the reserved region
  */
-vm_memory_reservation_t *vm_reserve_anon_memory(vm_t *vm, size_t size,
+vm_memory_reservation_t *vm_reserve_anon_memory(vm_t *vm, size_t size, size_t align,
                                                 memory_fault_callback_fn fault_callback, void *cookie, uintptr_t *addr);
 
 /*** vm_memory_make_anon(vm, addr, size)

--- a/libsel4vm/src/guest_ram.c
+++ b/libsel4vm/src/guest_ram.c
@@ -324,7 +324,7 @@ uintptr_t vm_ram_register(vm_t *vm, size_t bytes)
     int err;
     uintptr_t base_addr;
 
-    ram_reservation = vm_reserve_anon_memory(vm, bytes, default_ram_fault_callback, NULL, &base_addr);
+    ram_reservation = vm_reserve_anon_memory(vm, bytes, 0x1000, default_ram_fault_callback, NULL, &base_addr);
     if (!ram_reservation) {
         ZF_LOGE("Unable to reserve ram region of size 0x%x", bytes);
         return 0;

--- a/libsel4vmmplatsupport/src/arch/x86/drivers/vmm_pci_helper.c
+++ b/libsel4vmmplatsupport/src/arch/x86/drivers/vmm_pci_helper.c
@@ -39,6 +39,11 @@ int vmm_pci_helper_map_bars(vm_t *vm, libpci_device_iocfg_t *cfg, vmm_pci_bar_t 
                 ZF_LOGE("Failed to reserve PCI bar %p size %zu", (void *)(uintptr_t)cfg->base_addr[i], size);
                 return -1;
             }
+            /* Make sure that the address is naturally aligned to its size */
+            if (addr % size) {
+                ZF_LOGE("Guest PCI bar address %p is not aligned to size %zu", addr, size);
+                return -1;
+            }
             int err = map_ut_alloc_reservation_with_base_paddr(vm, (uintptr_t)cfg->base_addr[i], reservation);
             if (err) {
                 ZF_LOGE("Failed to map PCI bar %p size %zu", (void *)(uintptr_t)cfg->base_addr[i], size);

--- a/libsel4vmmplatsupport/src/arch/x86/drivers/vmm_pci_helper.c
+++ b/libsel4vmmplatsupport/src/arch/x86/drivers/vmm_pci_helper.c
@@ -33,7 +33,8 @@ int vmm_pci_helper_map_bars(vm_t *vm, libpci_device_iocfg_t *cfg, vmm_pci_bar_t 
         if (cfg->base_addr_space[i] == PCI_BASE_ADDRESS_SPACE_MEMORY) {
             /* Need to map into the VMM. Make sure it is aligned */
             uintptr_t addr;
-            vm_memory_reservation_t *reservation = vm_reserve_anon_memory(vm, size, default_error_fault_callback, NULL,
+            vm_memory_reservation_t *reservation = vm_reserve_anon_memory(vm, size, size,
+                                                                          default_error_fault_callback, NULL,
                                                                           &addr);
             if (!reservation) {
                 ZF_LOGE("Failed to reserve PCI bar %p size %zu", (void *)(uintptr_t)cfg->base_addr[i], size);

--- a/libsel4vmmplatsupport/src/arch/x86/guest_boot_init.c
+++ b/libsel4vmmplatsupport/src/arch/x86/guest_boot_init.c
@@ -94,7 +94,7 @@ static void make_guest_screen_info(vm_t *vm, struct screen_info *info)
             ZF_LOGE("Failed to map vbe protected mode interface for VESA frame buffer. Disabling");
         } else {
             fbuffer_size = vmm_plat_vesa_fbuffer_size(&vbeinfo.vbeModeInfoBlock);
-            vm_memory_reservation_t *reservation = vm_reserve_anon_memory(vm, fbuffer_size,
+            vm_memory_reservation_t *reservation = vm_reserve_anon_memory(vm, fbuffer_size, 0x1000,
                                                                           default_error_fault_callback, NULL, &base);
             if (!reservation) {
                 ZF_LOGE("Failed to reserve base pointer for VESA frame buffer. Disabling");


### PR DESCRIPTION
These two commits fix #12. I'm not very familiar with this code base, I hope I'm not breaking more than I'm fixing here.

In particular this PR changes the prototype of `vm_reserve_anon_memory` to add a requested address alignment. For backward compatibility an alternative could be to add a new variant of this function, say `vm_reserve_anon_memory_aligned`, and have `vm_reserve_anon_memory` call `vm_reserve_anon_memory_aligned` with a requested alignment of one page. I'd happily do so if you think it's better.