### PR TITLE
vgic.h: global should be declared extern

### DIFF
--- a/libsel4vm/src/arch/arm/vgic/vgic.h
+++ b/libsel4vm/src/arch/arm/vgic/vgic.h
@@ -12,7 +12,7 @@ struct vgic_dist_device {
     void *priv;
 };
 
-const struct vgic_dist_device dev_vgic_dist;
+extern const struct vgic_dist_device dev_vgic_dist;
 
 int vm_install_vgic(vm_t *vm);
 int vm_vgic_maintenance_handler(vm_vcpu_t *vcpu);


### PR DESCRIPTION
gcc before version 10 silently merged these, from v10 on the linker fails with multiply defined symbols. We could pass `-fcommon` to get the old gcc behaviour, but it's better to fix the code.
