### PR TITLE
.github: Remove ARMv6 tests

### DIFF
--- a/.github/workflows/sel4test-sim.yml
+++ b/.github/workflows/sel4test-sim.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        march: [armv6a, armv7a, armv8a, nehalem, rv32imac, rv64imac]
+        march: [armv7a, armv8a, nehalem, rv32imac, rv64imac]
         compiler: [gcc, clang]
         exclude:
           - march: rv32imac


### PR DESCRIPTION
ARMv6 is no longer supported.

See: seL4/seL4#578