### PR TITLE
trivial: Fixup compiler warnings

### DIFF
--- a/libsel4nanopb/src/common.c
+++ b/libsel4nanopb/src/common.c
@@ -12,14 +12,14 @@
 
 pb_ostream_t pb_ostream_from_IPC(seL4_Word offset)
 {
-    char *msg_buffer = (char *) & (seL4_GetIPCBuffer()->msg[offset]);
+    pb_byte_t *msg_buffer = (pb_byte_t *) & (seL4_GetIPCBuffer()->msg[offset]);
     size_t size = seL4_MsgMaxLength * sizeof(seL4_Word) - offset;
     return pb_ostream_from_buffer(msg_buffer, size);
 }
 
 pb_istream_t pb_istream_from_IPC(seL4_Word offset)
 {
-    char *msg_buffer = (char *) & (seL4_GetIPCBuffer()->msg[offset]);
+    pb_byte_t *msg_buffer = (pb_byte_t *) & (seL4_GetIPCBuffer()->msg[offset]);
     size_t size = seL4_MsgMaxLength * sizeof(seL4_Word) - offset;
     return pb_istream_from_buffer(msg_buffer, size);
 }

--- a/libsel4rpc/src/client.c
+++ b/libsel4rpc/src/client.c
@@ -19,6 +19,7 @@ int sel4rpc_client_init(sel4rpc_client_t *client, seL4_CPtr server_ep, seL4_Word
 {
     client->server_ep = server_ep;
     client->magic = magic;
+    return 0;
 }
 
 int sel4rpc_call(sel4rpc_client_t *client, RpcMessage *msg, seL4_CPtr root,


### PR DESCRIPTION
- Add missing return statement
- Use correct protobuf stream types.

Signed-off-by: Kent McLeod <kent@kry10.com>