### PR TITLE
SMC Capability

### DIFF
--- a/libsel4vm/CMakeLists.txt
+++ b/libsel4vm/CMakeLists.txt
@@ -67,6 +67,7 @@ target_include_directories(
 )
 target_link_libraries(
     sel4vm
+    sel4vmmplatsupport
     muslc
     sel4
     sel4simple

--- a/libsel4vm/arch_include/arm/sel4vm/arch/guest_vm_arch.h
+++ b/libsel4vm/arch_include/arm/sel4vm/arch/guest_vm_arch.h
@@ -15,15 +15,24 @@
 #include <sel4vm/guest_vm.h>
 
 typedef struct fault fault_t;
+typedef struct vm vm_t;
 typedef struct vm_vcpu vm_vcpu_t;
 
+typedef int (*smc_handler_callback_fn)(vm_vcpu_t *vcpu, seL4_UserContext *regs);
 typedef int (*unhandled_vcpu_fault_callback_fn)(vm_vcpu_t *vcpu, uint32_t hsr, void *cookie);
 
 #define VM_CSPACE_SIZE_BITS    4
 #define VM_FAULT_EP_SLOT       1
 #define VM_CSPACE_SLOT         VM_FAULT_EP_SLOT + CONFIG_MAX_NUM_NODES
 
-struct vm_arch {};
+/***
+ * @struct vm_arch
+ * Structure representing ARM specific vm properties
+ * @param {smc_handler_callback_fn} vm_smc_handler     A callback for a custom SMC call handler
+ */
+struct vm_arch {
+    smc_handler_callback_fn vm_smc_handler;
+};
 
 /***
  * @struct vm_vcpu_arch
@@ -48,3 +57,23 @@ struct vm_vcpu_arch {
  */
 int vm_register_unhandled_vcpu_fault_callback(vm_vcpu_t *vcpu, unhandled_vcpu_fault_callback_fn vcpu_fault_callback,
                                               void *cookie);
+
+/***
+ * @function vm_register_smc_handler_callback(vm, vm_smc_handler)
+ * Register a callback for a user level SMC handler to replace vm_smc_handle_default.
+ * This is useful when custom behavior, such as SMC emulation or forwarding device
+ * specific SMC calls to the Secure Monitor is needed.
+ *
+ * If default behavior is still required after custom processing the default handler can
+ * still be called from the callback.
+ *
+ * To forward an SMC call to the Secure Monitor, use smc_forward.
+ *
+ * On error return the guest will fault. Return 0 and use smc_set_return_value to
+ * return -1 to the VM without stopping it.
+ *
+ * @param {vm_t *} vm                  A handle to the VM
+ * @param {smc_handler_callback_fn}    A user supplied callback to handle VM SMC calls
+ * @return                             0 on success, -1 on error
+ */
+int vm_register_smc_handler_callback(vm_t *vm, smc_handler_callback_fn vm_smc_handler);

--- a/libsel4vm/src/arch/arm/boot.c
+++ b/libsel4vm/src/arch/arm/boot.c
@@ -21,6 +21,7 @@
 #include <sel4vm/guest_vm.h>
 #include <sel4vm/guest_vm_util.h>
 #include <sel4vm/arch/guest_arm_context.h>
+#include <sel4vmmplatsupport/arch/smc.h>
 
 #include "arm_vm.h"
 #include "vm_boot.h"
@@ -40,6 +41,10 @@ int vm_init_arch(vm_t *vm)
         ZF_LOGE("Failed to initialise vm arch: Invalid vm");
         return -1;
     }
+
+    /* Set arch default values */
+    err = vm_register_smc_handler_callback(vm, vm_smc_handle_default);
+    assert(!err);
 
     /* Create a cspace */
     vka = vm->vka;

--- a/libsel4vm/src/arch/arm/vm.c
+++ b/libsel4vm/src/arch/arm/vm.c
@@ -210,6 +210,22 @@ int vm_register_unhandled_vcpu_fault_callback(vm_vcpu_t *vcpu, unhandled_vcpu_fa
 
 }
 
+int vm_register_smc_handler_callback(vm_t *vm, smc_handler_callback_fn vm_smc_handler)
+{
+    if (!vm) {
+        ZF_LOGE("Failed to register smc_handler callback: Invalid VCPU handle");
+        return -1;
+    }
+
+    if (!vm_smc_handler) {
+        ZF_LOGE("Failed to register smc_handler callback: Invalid callback");
+        return -1;
+    }
+    vm->arch.vm_smc_handler = vm_smc_handler;
+
+    return 0;
+}
+
 int vm_run_arch(vm_t *vm)
 {
     int err;

--- a/libsel4vmmplatsupport/arch_include/arm/sel4vmmplatsupport/arch/smc.h
+++ b/libsel4vmmplatsupport/arch_include/arm/sel4vmmplatsupport/arch/smc.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023, DornerWorks
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <sel4vm/guest_vm.h>
+
+/* SMC Helpers */
+seL4_Word smc_get_function_id(seL4_UserContext *u);
+seL4_Word smc_set_return_value(seL4_UserContext *u, seL4_Word val);
+seL4_Word smc_get_arg(seL4_UserContext *u, seL4_Word arg);
+void smc_set_arg(seL4_UserContext *u, seL4_Word arg, seL4_Word val);
+
+/***
+ * @function smc_forward(vm_vcpu_t *vcpu, seL4_UserContext *regs, seL4_ARM_SMC smc_cap)
+ * Forward an SMC call using the appropriate capability
+ * @param {vm_vcpu_t *} vcpu           A handle to the VCPU
+ * @param {seL4_UserContext *} regs    A handle to the registers from the calling thread that want to make an SMC call
+ * @param {seL4_ARM_SMC} smc_cap       The SMC capability for the requested call
+ * @return                             0 on success, -1 on error
+ */
+int smc_forward(vm_vcpu_t *vcpu, seL4_UserContext *regs, seL4_ARM_SMC smc_cap);
+
+/***
+ * @function vm_smc_handle_default(vm_vcpu_t *vcpu, seL4_UserContext *regs)
+ * The default handler SMC faults. Will be called if a custom handler is not set for any given VM.
+ * @param {vm_vcpu_t *} vcpu           A handle to the VCPU
+ * @param {seL4_UserContext *} regs    A handle to the registers from the calling thread that want to make an SMC call
+ * @return                             0 on success, -1 on error
+ */
+int vm_smc_handle_default(vm_vcpu_t *vcpu, seL4_UserContext *regs);

--- a/libsel4vmmplatsupport/src/arch/arm/psci.c
+++ b/libsel4vmmplatsupport/src/arch/arm/psci.c
@@ -36,36 +36,30 @@ static int start_new_vcpu(vm_vcpu_t *vcpu,  uintptr_t entry_address, uintptr_t c
     return 0;
 }
 
-int handle_psci(vm_vcpu_t *vcpu, seL4_Word fn_number, bool convention)
+int handle_psci(vm_vcpu_t *vcpu, seL4_UserContext *regs, seL4_Word fn_number, bool convention)
 {
     int err;
-    seL4_UserContext regs;
-    err = vm_get_thread_context(vcpu, &regs);
-    if (err) {
-        ZF_LOGE("Failed to get vcpu registers");
-        return -1;
-    }
     switch (fn_number) {
     case PSCI_VERSION:
-        smc_set_return_value(&regs, 0x00010000); /* version 1 */
+        smc_set_return_value(regs, 0x00010000); /* version 1 */
         break;
     case PSCI_CPU_ON: {
-        uintptr_t target_cpu = smc_get_arg(&regs, 1);
-        uintptr_t entry_point_address = smc_get_arg(&regs, 2);
-        uintptr_t context_id = smc_get_arg(&regs, 3);
+        uintptr_t target_cpu = smc_get_arg(regs, 1);
+        uintptr_t entry_point_address = smc_get_arg(regs, 2);
+        uintptr_t context_id = smc_get_arg(regs, 3);
         vm_vcpu_t *target_vcpu = vm_vcpu_for_target_cpu(vcpu->vm, target_cpu);
         if (target_vcpu == NULL) {
             target_vcpu = vm_find_free_unassigned_vcpu(vcpu->vm);
             if (target_vcpu && start_new_vcpu(target_vcpu, entry_point_address, context_id, target_cpu) == 0) {
-                smc_set_return_value(&regs, PSCI_SUCCESS);
+                smc_set_return_value(regs, PSCI_SUCCESS);
             } else {
-                smc_set_return_value(&regs, PSCI_INTERNAL_FAILURE);
+                smc_set_return_value(regs, PSCI_INTERNAL_FAILURE);
             }
         } else {
             if (is_vcpu_online(target_vcpu)) {
-                smc_set_return_value(&regs, PSCI_ALREADY_ON);
+                smc_set_return_value(regs, PSCI_ALREADY_ON);
             } else {
-                smc_set_return_value(&regs, PSCI_INTERNAL_FAILURE);
+                smc_set_return_value(regs, PSCI_INTERNAL_FAILURE);
             }
         }
 
@@ -73,24 +67,18 @@ int handle_psci(vm_vcpu_t *vcpu, seL4_Word fn_number, bool convention)
     }
     case PSCI_MIGRATE_INFO_TYPE:
         /* trusted OS does not require migration */
-        smc_set_return_value(&regs, 2);
+        smc_set_return_value(regs, 2);
         break;
     case PSCI_FEATURES:
         /* TODO Not sure if required */
-        smc_set_return_value(&regs, PSCI_NOT_SUPPORTED);
+        smc_set_return_value(regs, PSCI_NOT_SUPPORTED);
         break;
     case PSCI_SYSTEM_RESET:
-        smc_set_return_value(&regs, PSCI_SUCCESS);
+        smc_set_return_value(regs, PSCI_SUCCESS);
         break;
     default:
         ZF_LOGE("Unhandled PSCI function id %lu\n", fn_number);
         return -1;
     }
-    err = vm_set_thread_context(vcpu, regs);
-    if (err) {
-        ZF_LOGE("Failed to set vcpu context registers");
-        return -1;
-    }
-    advance_vcpu_fault(vcpu);
     return 0;
 }

--- a/libsel4vmmplatsupport/src/arch/arm/psci.h
+++ b/libsel4vmmplatsupport/src/arch/arm/psci.h
@@ -51,4 +51,4 @@ typedef enum psci {
     PSCI_MAX = 0x1f
 } psci_id_t;
 
-int handle_psci(vm_vcpu_t *vcpu, seL4_Word fn_number, bool convention);
+int handle_psci(vm_vcpu_t *vcpu, seL4_UserContext *regs, seL4_Word fn_number, bool convention);

--- a/libsel4vmmplatsupport/src/arch/arm/smc.h
+++ b/libsel4vmmplatsupport/src/arch/arm/smc.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <sel4vm/guest_vm.h>
+#include <sel4vmmplatsupport/arch/smc.h>
 
 /* Values in this file are taken from:
  * SMC CALLING CONVENTION
@@ -40,9 +41,3 @@ typedef enum {
 
 /* SMC VCPU fault handler */
 int handle_smc(vm_vcpu_t *vcpu, uint32_t hsr);
-
-/* SMC Helpers */
-seL4_Word smc_get_function_id(seL4_UserContext *u);
-seL4_Word smc_set_return_value(seL4_UserContext *u, seL4_Word val);
-seL4_Word smc_get_arg(seL4_UserContext *u, seL4_Word arg);
-void smc_set_arg(seL4_UserContext *u, seL4_Word arg, seL4_Word val);

--- a/libsel4vmmplatsupport/src/sel4_arch/aarch64/smc.c
+++ b/libsel4vmmplatsupport/src/sel4_arch/aarch64/smc.c
@@ -34,8 +34,10 @@ seL4_Word smc_get_arg(seL4_UserContext *u, seL4_Word arg)
         return u->x5;
     case 6:
         return u->x6;
+    case 7:
+        return u->x7;
     default:
-        ZF_LOGF("SMC only has 6 argument registers");
+        ZF_LOGF("SMC only has 7 argument registers");
     }
 }
 
@@ -60,7 +62,46 @@ void smc_set_arg(seL4_UserContext *u, seL4_Word arg, seL4_Word val)
     case 6:
         u->x6 = val;
         break;
+    case 7:
+        u->x7 = val;
+        break;
     default:
-        ZF_LOGF("SMC only has 6 argument registers");
+        ZF_LOGF("SMC only has 7 argument registers");
     }
+}
+
+int smc_forward(vm_vcpu_t *vcpu, seL4_UserContext *regs, seL4_ARM_SMC smc_cap)
+{
+    int err = 0;
+    seL4_ARM_SMCContext smc_args;
+    seL4_ARM_SMCContext smc_results;
+
+    /* Get function and arguments from guest */
+    smc_args.x0 = regs->x0;
+    smc_args.x1 = regs->x1;
+    smc_args.x2 = regs->x2;
+    smc_args.x3 = regs->x3;
+    smc_args.x4 = regs->x4;
+    smc_args.x5 = regs->x5;
+    smc_args.x6 = regs->x6;
+    smc_args.x7 = regs->x7;
+
+    /* Make systemcall */
+    err = seL4_ARM_SMC_Call(smc_cap, &smc_args, &smc_results);
+    if (err) {
+        ZF_LOGE("Failure during seL4_ARM_SMC_Call function %lu\n", smc_args.x0);
+        return -1;
+    }
+
+    /* Send SMC results back to guest */
+    regs->x0 = smc_results.x0;
+    regs->x1 = smc_results.x1;
+    regs->x2 = smc_results.x2;
+    regs->x3 = smc_results.x3;
+    regs->x4 = smc_results.x4;
+    regs->x5 = smc_results.x5;
+    regs->x6 = smc_results.x6;
+    regs->x7 = smc_results.x7;
+
+    return 0;
 }


### PR DESCRIPTION
Add a new capability which certain threads can invoke so seL4 can make SMC calls on ARM platforms in EL2 (virtualized mode) on the thread’s behalf.

See https://sel4.atlassian.net/browse/RFC-9
