### PR TITLE
libsel4vm: remove obsolete includes

### DIFF
--- a/libsel4vm/src/arch/arm/fault.c
+++ b/libsel4vm/src/arch/arm/fault.c
@@ -12,7 +12,6 @@
 #include "arch_fault.h"
 
 #include <sel4/sel4.h>
-#include <sel4/messages.h>
 #include <vka/capops.h>
 
 #include <utils/ansi.h>

--- a/libsel4vm/src/arch/arm/syscalls.c
+++ b/libsel4vm/src/arch/arm/syscalls.c
@@ -9,7 +9,6 @@
 #include <stdlib.h>
 
 #include <sel4/sel4.h>
-#include <sel4/messages.h>
 #include <utils/util.h>
 
 #include <sel4vm/guest_vm_util.h>

--- a/libsel4vm/src/arch/arm/vm.c
+++ b/libsel4vm/src/arch/arm/vm.c
@@ -9,7 +9,6 @@
 #include <stdlib.h>
 
 #include <sel4/sel4.h>
-#include <sel4/messages.h>
 
 #include <sel4vm/guest_vm.h>
 #include <sel4vm/guest_vm_util.h>

--- a/libsel4vm/src/arch/x86/vm.c
+++ b/libsel4vm/src/arch/x86/vm.c
@@ -10,7 +10,6 @@
 #include <string.h>
 
 #include <sel4/sel4.h>
-#include <sel4/messages.h>
 #include <platsupport/arch/tsc.h>
 #include <sel4/arch/vmenter.h>
 #include <vka/capops.h>


### PR DESCRIPTION
This include file is deprecated since 2016, and it seems there's nothing in there that is needed. Removing the reference here is a preparation to delete this file from the kernel includes completely.

See https://github.com/axel-h/camkes-vm/pull/2 for CI tests.