### PR TITLE
 libsel4vmmplatsupport: fixed left shift overflow

### DIFF
--- a/libsel4vmmplatsupport/src/drivers/virtio_emul.c
+++ b/libsel4vmmplatsupport/src/drivers/virtio_emul.c
@@ -86,7 +86,7 @@ static int emul_io_out(virtio_emul_t *emul, unsigned int offset, unsigned int si
         assert(size == 4);
         int queue = emul->virtq.queue;
         emul->virtq.queue_pfn[queue] = value;
-        vring_init(&emul->virtq.vring[queue], emul->virtq.queue_size[queue], (void *)(uintptr_t)(value << 12),
+        vring_init(&emul->virtq.vring[queue], emul->virtq.queue_size[queue], (void *)((uintptr_t)value << 12),
                    VIRTIO_PCI_VRING_ALIGN);
         break;
     }


### PR DESCRIPTION
 Error:"vm_ram_touch@guest_ram.c:157
 Failed to touch ram region: Not registered RAM region"
 
 Rootcause:if value(unsigned int) is larger than 0x100000
 (it is common when the memory of VM allocated exceeds 3G),
 and then left shift 12 bit, the highest bits 0x1 of value will be lost.

 Signed-off-by: hanjinglong <hjlallen@qq.com>