### PR TITLE
add missing brackets

### DIFF
--- a/libsel4vm/src/arch/arm/arm_vm.h
+++ b/libsel4vm/src/arch/arm/arm_vm.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#define VCPU_BADGE_CREATE(idx)  idx + 1
-#define VCPU_BADGE_IDX(badge)   badge - 1
+#define VCPU_BADGE_CREATE(idx)  ((idx) + 1)
+#define VCPU_BADGE_IDX(badge)   ((badge) - 1)
 #define MAX_VCPU_BADGE          CONFIG_MAX_NUM_NODES
 #define MIN_VCPU_BADGE          1

--- a/libsel4vm/src/arch/arm/vgic/vgic.c
+++ b/libsel4vm/src/arch/arm/vgic/vgic.c
@@ -100,7 +100,7 @@
 #define MAX_VIRQS   200
 #define NUM_SGI_VIRQS   16
 #define NUM_PPI_VIRQS   16
-#define GIC_SPI_IRQ_MIN      NUM_SGI_VIRQS + NUM_PPI_VIRQS
+#define GIC_SPI_IRQ_MIN      (NUM_SGI_VIRQS + NUM_PPI_VIRQS)
 
 /* GIC Distributor register access utilities */
 #define GIC_DIST_REGN(offset, reg) ((offset-reg)/sizeof(uint32_t))


### PR DESCRIPTION
For macos, expressions must be made atoms to avoid side effects.