### PR TITLE
libsel4vm: use constant

### DIFF
--- a/libsel4vm/src/arch/arm/vgic/vgic.c
+++ b/libsel4vm/src/arch/arm/vgic/vgic.c
@@ -860,7 +860,7 @@ static memory_fault_result_t handle_vgic_dist_write_fault(vm_t *vm, vm_vcpu_t *v
             int irq;
             irq = CTZ(data);
             data &= ~(1U << irq);
-            irq += (offset - 0x280) * 8;
+            irq += (offset - GIC_DIST_ICPENDR0) * 8;
             vgic_dist_clr_pending_irq(d, vcpu, irq);
         }
         break;


### PR DESCRIPTION
Another trivial code cleanup. 
At first I though this is something related to the misalignment fixed by https://github.com/seL4/seL4_projects_libs/pull/29 but it seems this just slipped in at e83bf5727db38f8ce899800d09555f930cad1217.