### PR TITLE
libsel4vm: fix line breaks in log messages

### DIFF
--- a/libsel4vm/src/arch/arm/vgic/vgic.c
+++ b/libsel4vm/src/arch/arm/vgic/vgic.c
@@ -280,7 +280,7 @@ static int virq_sgi_ppi_add(vm_vcpu_t *vcpu, vgic_t *vgic, struct virq_handle *v
     assert((irq >= 0) && (irq < ARRAY_SIZE(vgic_vcpu->local_virqs)));
     virq_handle_t *slot = &vgic_vcpu->local_virqs[irq];
     if (*slot != NULL) {
-        ZF_LOGE("IRQ %d already registered on VCPU %u\n", irq, vcpu->vcpu_id);
+        ZF_LOGE("IRQ %d already registered on VCPU %u", virq_data->virq, vcpu->vcpu_id);
         return -1;
     }
     *slot = virq_data;
@@ -552,7 +552,7 @@ static int vgic_dist_enable_irq(struct vgic_dist_device *d, vm_vcpu_t *vcpu, int
             virq_ack(vcpu, virq_data);
         }
     } else {
-        DDIST("enabled irq %d has no handle", irq);
+        DDIST("enabled irq %d has no handle\n", irq);
     }
     return 0;
 }
@@ -767,7 +767,7 @@ static memory_fault_result_t handle_vgic_dist_read_fault(vm_t *vm, vm_vcpu_t *vc
         reg = *reg_ptr;
         break;
     default:
-        ZF_LOGE("Unknown register offset 0x%x\n", offset);
+        ZF_LOGE("Unknown register offset 0x%x", offset);
         err = ignore_fault(fault);
         goto fault_return;
     }
@@ -949,7 +949,7 @@ static memory_fault_result_t handle_vgic_dist_write_fault(vm_t *vm, vm_vcpu_t *v
     case RANGE32(0xFC0, 0xFFB):
         break;
     default:
-        ZF_LOGE("Unknown register offset 0x%x\n", offset);
+        ZF_LOGE("Unknown register offset 0x%x", offset);
     }
 ignore_fault:
     err = ignore_fault(fault);
@@ -1079,7 +1079,7 @@ static vm_frame_t vgic_vcpu_iterator(uintptr_t addr, void *cookie)
 
     int err = vka_cspace_alloc_path(vm->vka, &frame);
     if (err) {
-        printf("Failed to allocate cslot for vgic vcpu\n");
+        ZF_LOGE("Failed to allocate cslot for vgic vcpu");
         return frame_result;
     }
     seL4_Word vka_cookie;
@@ -1087,7 +1087,7 @@ static vm_frame_t vgic_vcpu_iterator(uintptr_t addr, void *cookie)
     if (err) {
         err = simple_get_frame_cap(vm->simple, (void *)GIC_VCPU_PADDR, 12, &frame);
         if (err) {
-            ZF_LOGE("Failed to find device cap for vgic vcpu\n");
+            ZF_LOGE("Failed to find device cap for vgic vcpu");
             return frame_result;
         }
     }


### PR DESCRIPTION
clean up log messages:
- fix line breaks in log messages
- use ZF_LOGx() instead of printf()
