### PR TITLE
libsel4vm: leave IPC details in VM code

### DIFF
--- a/libsel4vm/src/arch/arm/vgic/vgic.h
+++ b/libsel4vm/src/arch/arm/vgic/vgic.h
@@ -15,4 +15,4 @@ struct vgic_dist_device {
 extern const struct vgic_dist_device dev_vgic_dist;
 
 int vm_install_vgic(vm_t *vm);
-int vm_vgic_maintenance_handler(vm_vcpu_t *vcpu);
+int vm_vgic_maintenance(vm_vcpu_t *vcpu, int lr_idx);


### PR DESCRIPTION
- keep vgic code agnostic of IPC details. Currently it is a bit odd how thing are split between vm.c and vgic.c, having vgic agnostic of the notification details allows better reusing/testing the code.
- inline handle_vgic_maintenance(), simplified the code
- use ZF_LOGE() instead of ZF_LOGF(), caller stops on error anyway.