### PR TITLE
libsel4vm: change vcpu thread naming scheme

### DIFF
--- a/libsel4vm/src/arch/arm/boot.c
+++ b/libsel4vm/src/arch/arm/boot.c
@@ -19,6 +19,7 @@
 
 #include <sel4vm/boot.h>
 #include <sel4vm/guest_vm.h>
+#include <sel4vm/guest_vm_util.h>
 #include <sel4vm/arch/guest_arm_context.h>
 
 #include "arm_vm.h"
@@ -109,5 +110,12 @@ int vm_create_vcpu_arch(vm_t *vm, vm_vcpu_t *vcpu)
         err = -1;
     }
 #endif /* CONFIG_MAX_NUM_NODES > 1 */
+
+#ifdef CONFIG_DEBUG_BUILD
+    char vcpu_name[32];
+    snprintf(vcpu_name, sizeof(vcpu_name), "%s:%d", vm->vm_name, vcpu->vcpu_id);
+    seL4_DebugNameThread(vm_get_vcpu_tcb(vcpu), vcpu_name);
+#endif
+
     return err;
 }


### PR DESCRIPTION
This makes it easier to differentiate between the vcpu threads when debugging and/or testing