### PR TITLE
Add zynqmp support to libsel4vm

### DIFF
--- a/libsel4dma/src/dma.c
+++ b/libsel4dma/src/dma.c
@@ -28,6 +28,8 @@
 #define DMA_MINALIGN_BYTES 32
 #elif defined(CONFIG_PLAT_EXYNOS5)
 #define DMA_MINALIGN_BYTES 32
+#elif defined(CONFIG_PLAT_ZYNQMP)
+#define DMA_MINALIGN_BYTES 32
 #else
 #warning Unknown platform. DMA alignment defaulting to 32 bytes.
 #define DMA_MINALIGN_BYTES 32

--- a/libsel4vm/src/arch/arm/vgic/gicv2.h
+++ b/libsel4vm/src/arch/arm/vgic/gicv2.h
@@ -22,6 +22,8 @@
 #define GIC_PADDR   0x8000000
 #elif defined(CONFIG_PLAT_ODROIDC2)
 #define GIC_PADDR   0xc4300000
+#elif defined(CONFIG_PLAT_ZYNQMP)
+#define GIC_PADDR   0xf9000000
 #else
 #error "Unsupported platform for GIC"
 #endif
@@ -31,6 +33,11 @@
 #define GIC_CPU_PADDR        (GIC_PADDR + 0x00010000)
 #define GIC_VCPU_CNTR_PADDR  (GIC_PADDR + 0x00030000)
 #define GIC_VCPU_PADDR       (GIC_PADDR + 0x00040000)
+#elif defined(CONFIG_PLAT_ZYNQMP)
+#define GIC_DIST_PADDR       (GIC_PADDR + 0x10000)
+#define GIC_CPU_PADDR        (GIC_PADDR + 0x20000)
+#define GIC_VCPU_CNTR_PADDR  (GIC_PADDR + 0x40000)
+#define GIC_VCPU_PADDR       (GIC_PADDR + 0x60000)
 #else
 #define GIC_DIST_PADDR       (GIC_PADDR + 0x1000)
 #define GIC_CPU_PADDR        (GIC_PADDR + 0x2000)

--- a/libsel4vmmplatsupport/plat_include/zynqmp/sel4vmmplatsupport/plat/device_map.h
+++ b/libsel4vmmplatsupport/plat_include/zynqmp/sel4vmmplatsupport/plat/device_map.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2019, DornerWorks
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once

--- a/libsel4vmmplatsupport/plat_include/zynqmp/sel4vmmplatsupport/plat/devices.h
+++ b/libsel4vmmplatsupport/plat_include/zynqmp/sel4vmmplatsupport/plat/devices.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2019, DornerWorks
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once

--- a/libsel4vmmplatsupport/plat_include/zynqmp/sel4vmmplatsupport/plat/guest_vcpu_util.h
+++ b/libsel4vmmplatsupport/plat_include/zynqmp/sel4vmmplatsupport/plat/guest_vcpu_util.h
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2019, DornerWorks
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#define PLAT_CPU_COMPAT "arm,cortex-a53"

--- a/libsel4vmmplatsupport/plat_include/zynqmp/sel4vmmplatsupport/plat/vpci.h
+++ b/libsel4vmmplatsupport/plat_include/zynqmp/sel4vmmplatsupport/plat/vpci.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019, DornerWorks
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+/* PCI host bridge memory regions are defined in the pci dts node
+ * supplied to the Linux guest. These values are also reflected here.
+ */
+
+/* PCI host bridge configration space */
+#define PCI_CFG_REGION_ADDR 0x3E000000
+/* PCI host bridge IO space */
+#define PCI_IO_REGION_ADDR 0x3D000000
+/* Size of PCI configuration space */
+#define PCI_CFG_REGION_SIZE 0x1000000
+/* Size of PCI IO space  */
+#define PCI_IO_REGION_SIZE 0x10000
+/* PCI memory space */
+#define PCI_MEM_REGION_ADDR 0x3F000000ull
+/* PCI memory space size */
+#define PCI_MEM_REGION_SIZE 0x1000000
+
+/* FDT IRQ controller address cells definition */
+#define GIC_ADDRESS_CELLS 0x1

--- a/libsel4vmmplatsupport/src/arch/arm/guest_image.c
+++ b/libsel4vmmplatsupport/src/arch/arm/guest_image.c
@@ -209,7 +209,7 @@ static void *load_guest_kernel_image(vm_t *vm, const char *kernel_image_name, ui
     switch (ret_file_type) {
     case IMG_BIN:
         if (config_set(CONFIG_PLAT_TX1) || config_set(CONFIG_PLAT_TX2) || config_set(CONFIG_PLAT_QEMU_ARM_VIRT)
-            || config_set(CONFIG_PLAT_ODROIDC2)) {
+            || config_set(CONFIG_PLAT_ODROIDC2) || config_set(CONFIG_PLAT_ZYNQMP)) {
             /* This is likely an aarch64/aarch32 linux difference */
             load_addr = load_base_addr + 0x80000;
         } else {


### PR DESCRIPTION
I know its not a supported platform yet, but this should be able to be merged and it will be ready when the camkes-vm officially supports the board.