### PR TITLE
libsel4vm: add entries to vm structure

### DIFF
--- a/libsel4vm/include/sel4vm/guest_vm.h
+++ b/libsel4vm/include/sel4vm/guest_vm.h
@@ -77,6 +77,8 @@ struct vm_ram_region {
  * @param {vm_memory_reservation_cookie_t *}                                Initialised instance of vm memory interface
  * @param {unhandled_mem_fault_callback_fn}  unhandled_mem_fault_handler    Registered callback for unhandled memory faults
  * @param {void *} unhandled_mem_fault_cookie                               User data passed onto unhandled mem fault callback
+ * @param {int} clean_cache                                                 Flag to clean cache when loading images
+ * @param {int} map_one_to_one                                              Flag to tell VMM to map memory 1:1
  */
 struct vm_mem {
     /* Guest vm vspace management */
@@ -94,6 +96,8 @@ struct vm_mem {
     vm_memory_reservation_cookie_t *reservation_cookie;
     unhandled_mem_fault_callback_fn unhandled_mem_fault_handler;
     void *unhandled_mem_fault_cookie;
+    int clean_cache;
+    int map_one_to_one;
 };
 
 /***
@@ -177,6 +181,7 @@ struct vm_cspace {
  * @param {vka_t *} vka                 Handle to virtual kernel allocator for seL4 kernel object allocation
  * @param {ps_io_ops_t *} io_ops        Handle to platforms io ops
  * @param {simple_t *} simple           Handle to hosts simple environment
+ * @param {seL4_Word} entry             Entry address for the loaded kernel
  * @param {char *} vm_name              String used to describe VM. Useful for debugging
  * @param {unsigned int} vm_id          Identifier for VM. Useful for debugging
  * @param {bool} vm_initialised         Boolean flagging whether VM is intialised or not
@@ -199,6 +204,10 @@ struct vm {
     vka_t *vka;
     ps_io_ops_t *io_ops;
     simple_t *simple;
+
+    /* vm entry address */
+    seL4_Word entry;
+
     /* Debugging & Identification */
     char *vm_name;
     unsigned int vm_id;

--- a/libsel4vmmplatsupport/src/arch/arm/guest_image.c
+++ b/libsel4vmmplatsupport/src/arch/arm/guest_image.c
@@ -143,7 +143,7 @@ static int guest_write_address(vm_t *vm, uintptr_t paddr, void *vaddr, size_t si
         return -1;
     }
 
-    if (config_set(CONFIG_PLAT_TX1) || config_set(CONFIG_PLAT_TX2)) {
+    if (vm->mem.clean_cache) {
         seL4_CPtr cap = vspace_get_cap(&vm->mem.vmm_vspace, vaddr);
         if (cap == seL4_CapNull) {
             /* Not sure how we would get here, something has gone pretty wrong */
@@ -202,13 +202,7 @@ static void *load_guest_kernel_image(vm_t *vm, const char *kernel_image_name, ui
     /* Determine the load address */
     switch (ret_file_type) {
     case IMG_BIN:
-        if (config_set(CONFIG_PLAT_TX1) || config_set(CONFIG_PLAT_TX2) || config_set(CONFIG_PLAT_QEMU_ARM_VIRT)
-            || config_set(CONFIG_PLAT_ODROIDC2) || config_set(CONFIG_PLAT_ZYNQMP)) {
-            /* This is likely an aarch64/aarch32 linux difference */
-            load_addr = load_base_addr + 0x80000;
-        } else {
-            load_addr = load_base_addr + 0x8000;
-        }
+        load_addr = vm->entry;
         break;
     case IMG_ZIMAGE:
         load_addr = zImage_get_load_address(&header, load_base_addr);


### PR DESCRIPTION
This commit adds three entries to the vm structure. The first is the entry address of the loaded kernel. The second is a flag to determine whether the cache should be cleaned when loading images to the guest's address space. The third flag is whether the VM should map memory 1:1.

These flags are necessary to differentiate VMs in a multiple VM setup. For example, if two VMs have kernels with different entry points, only one VM would run, and the other would fault.

Test with: https://github.com/seL4/camkes-vm-examples/pull/31
Test with: https://github.com/seL4/camkes-vm/pull/48