### PR TITLE
libsel4vm: guest cpu requests to vcpus from pcpus

### DIFF
--- a/libsel4vm/include/sel4vm/guest_vm_util.h
+++ b/libsel4vm/include/sel4vm/guest_vm_util.h
@@ -73,6 +73,29 @@ static inline vm_vcpu_t *vm_find_free_unassigned_vcpu(vm_t *vm)
 }
 
 /***
+ * @function vm_find_free_unassigned_cpu(vm)
+ * Find an unallocated physical cpu
+ * @param {vm_t *} vm           A handle to the vm owning the vcpu
+ * @return                      -1 if no pcpu can be found, otherwise the available pcpu
+ */
+static inline int vm_find_free_unassigned_cpu(vm_t *vm)
+{
+    for (int core = 0; core < CONFIG_MAX_NUM_NODES; core++) {
+        int core_allocated = 0;
+        for (int i = 0; i < vm->num_vcpus; i++) {
+            if (vm->vcpus[i]->target_cpu == core) {
+                core_allocated = 1;
+                break;
+            }
+        }
+        if (!core_allocated) {
+            return core;
+        }
+    }
+    return -1;
+}
+
+/***
  * @function is_vcpu_online(vcpu)
  * Find if a given VCPU is online
  * @param {vm_vcpu_t *} vcpu    A handle to the vcpu


### PR DESCRIPTION
Originally the guests were able to make requests for a specific physical core based on its id. These changes associate that requested id with a vcpu instead of a pcpu.

Signed-off-by: Alex Pavey <Alex.Pavey@dornerworks.com>