### PR TITLE
trivial: fix compilation error

### DIFF
--- a/libsel4vmmplatsupport/src/drivers/virtio_console_emul.c
+++ b/libsel4vmmplatsupport/src/drivers/virtio_console_emul.c
@@ -10,7 +10,7 @@
 #include "virtio_emul_helpers.h"
 
 #define VUART_BUFLEN 4088
-char buf[VUART_BUFLEN];
+static char buf[VUART_BUFLEN];
 
 typedef struct console_virtio_emul_internal {
     struct console_passthrough driver;

--- a/libsel4vmmplatsupport/src/drivers/virtio_vsock_emul.c
+++ b/libsel4vmmplatsupport/src/drivers/virtio_vsock_emul.c
@@ -8,7 +8,7 @@
 #include "virtio_emul_helpers.h"
 
 /* Temporary buffer used during TX */
-char buf[VIRTIO_VSOCK_CAMKES_MTU];
+static char buf[VIRTIO_VSOCK_CAMKES_MTU];
 
 typedef struct vsock_internal {
     struct vsock_passthrough driver;


### PR DESCRIPTION
This PR should fix a compilation error of multiple definitions (happens [here](https://github.com/seL4/camkes-vm/actions/runs/3562948885/jobs/5985186431)).

My version of Debian doesn't support gcc-10 so I can't test this locally. Let see how the CIs go.