### PR TITLE
virtio: improvement for virtio vsock and virtio console

### DIFF
--- a/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_con.h
+++ b/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_con.h
@@ -21,15 +21,17 @@
 /***
  * @struct virtio_con
  * Virtio Console Driver Interface
- * @param {unsigned int} iobase                             IO Port base for virtio con device
- * @param {virtio_emul_t *} emul                            Virtio console emulation interface: VMM <-> Guest
- * @param {struct console_passthrough} emul_driver_funcs    Virtio console emulation functions: VMM <-> Guest
- * @param {ps_io_ops_t} ioops                               Platform support io ops datastructure
+ * @param {unsigned int} iobase                                 IO Port base for virtio con device
+ * @param {virtio_emul_t *} emul                                Virtio console emulation interface: VMM <-> Guest
+ * @param {struct eth_driver *} emul_driver                     Backend console driver interface: VMM <-> console driver
+ * @param {struct virtio_console_passthrough} emul_driver_funcs Virtio console emulation functions: VMM <-> Guest
+ * @param {ps_io_ops_t} ioops                                   Platform support io ops datastructure
  */
 typedef struct virtio_con {
     unsigned int iobase;
     virtio_emul_t *emul;
-    struct console_passthrough emul_driver_funcs;
+    struct virtio_console_driver *emul_driver;
+    struct virtio_console_passthrough emul_driver_funcs;
     ps_io_ops_t ioops;
 } virtio_con_t;
 
@@ -55,4 +57,4 @@ virtio_con_t *common_make_virtio_con(vm_t *vm,
                                      ioport_type_t port_type,
                                      unsigned int interrupt_pin,
                                      unsigned int interrupt_line,
-                                     struct console_passthrough backend);
+                                     struct virtio_console_passthrough backend);

--- a/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_pci_console.h
+++ b/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_pci_console.h
@@ -6,13 +6,44 @@
 
 #pragma once
 
-typedef void (*console_handle_irq_fn_t)(void *cookie);
+typedef struct virtio_emul virtio_emul_t;
+
 typedef void (*console_putchar_fn_t)(int port, char c);
 
-struct console_passthrough {
-    console_handle_irq_fn_t handleIRQ;
-    console_putchar_fn_t    putchar;
-    void                   *console_data;
+/***
+ * @struct virtio_console_callbacks
+ * Callback functions provided by the emul layer of virtio console
+ *
+ * @param backend_putchar putchar
+ */
+typedef struct virtio_console_callbacks {
+    void (*emul_putchar)(int port, virtio_emul_t *con, char *buffer, uint32_t head, uint32_t tail);
+} virtio_console_callbacks_t;
+
+/***
+ * @struct virtio_console_passthrough
+ * Virtion console backend layer interface
+ *
+ * @param handleIRQ handle IRQ
+ * @param backend_putchar putchar
+ * @param console_data data specified by the backend
+ */
+typedef struct virtio_console_passthrough {
+    void (*handleIRQ)(void *cookie);
+    console_putchar_fn_t backend_putchar;
+    void *console_data;
+} virtio_console_passthrough_t;
+
+/***
+ * @struct virtio_console_driver
+ * Structure to hold the interface for a virtio console driver
+ *
+ * @param backend_fn backend layer interface
+ * @param emul_cb emul layer interface
+ */
+struct virtio_console_driver {
+    virtio_console_passthrough_t backend_fn;
+    virtio_console_callbacks_t emul_cb;
 };
 
-typedef int (*console_driver_init)(struct console_passthrough *driver, ps_io_ops_t io_ops, void *config);
+typedef int (*console_driver_init)(struct virtio_console_driver *driver, ps_io_ops_t io_ops, void *config);

--- a/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_pci_vsock.h
+++ b/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_pci_vsock.h
@@ -5,14 +5,24 @@
  */
 #pragma once
 
-typedef void (*vsock_inject_irq_fn_t)(void *cookie);
+typedef struct virtio_emul virtio_emul_t;
+
 typedef void (*vsock_tx_forward_fn_t)(int cid, void *buffer, unsigned int len);
 
-struct vsock_passthrough {
+typedef struct virtio_vsock_callbacks {
+    void (*rx_complete)(virtio_emul_t *emul, char *buf, unsigned int len);
+} virtio_vsock_callbacks_t;
+
+typedef struct virtio_vsock_passthrough {
     int guest_cid;
-    vsock_inject_irq_fn_t injectIRQ;
+    void (*injectIRQ)(void *cookie);
     vsock_tx_forward_fn_t forward;
     void *vsock_data;
+} virtio_vsock_passthrough_t;
+
+struct virtio_vsock_driver {
+    virtio_vsock_passthrough_t backend_fn;
+    virtio_vsock_callbacks_t emul_cb;
 };
 
-typedef int (*vsock_driver_init)(struct vsock_passthrough *driver, ps_io_ops_t io_ops, void *config);
+typedef int (*vsock_driver_init)(struct virtio_vsock_driver *driver, ps_io_ops_t io_ops, void *config);

--- a/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_vsock.h
+++ b/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_vsock.h
@@ -14,7 +14,8 @@
 typedef struct virtio_vsock {
     unsigned int iobase;
     virtio_emul_t *emul;
-    struct vsock_passthrough emul_driver_funcs;
+    struct virtio_vsock_driver *emul_driver;
+    struct virtio_vsock_passthrough emul_driver_funcs;
     ps_io_ops_t ioops;
 } virtio_vsock_t;
 
@@ -25,4 +26,4 @@ virtio_vsock_t *common_make_virtio_vsock(vm_t *vm,
                                          ioport_type_t port_type,
                                          unsigned int interrupt_pin,
                                          unsigned int interrupt_line,
-                                         struct vsock_passthrough backend);
+                                         struct virtio_vsock_passthrough backend);

--- a/libsel4vmmplatsupport/src/drivers/virtio_con.c
+++ b/libsel4vmmplatsupport/src/drivers/virtio_con.c
@@ -42,10 +42,11 @@ static int virtio_con_io_out(void *cookie, unsigned int port_no, unsigned int si
     return 0;
 }
 
-static int emul_con_driver_init(struct console_passthrough *driver, ps_io_ops_t io_ops, void *config)
+static int emul_con_driver_init(struct virtio_console_driver *driver, ps_io_ops_t io_ops, void *config)
 {
     virtio_con_t *con = (virtio_con_t *)config;
-    *driver = con->emul_driver_funcs;
+    driver->backend_fn = con->emul_driver_funcs;
+    con->emul_driver = driver;
     return 0;
 }
 
@@ -88,7 +89,7 @@ static vmm_pci_entry_t vmm_virtio_console_pci_bar(unsigned int iobase,
 
 virtio_con_t *common_make_virtio_con(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *ioport,
                                      ioport_range_t ioport_range, ioport_type_t port_type, unsigned int interrupt_pin, unsigned int interrupt_line,
-                                     struct console_passthrough backend)
+                                     struct virtio_console_passthrough backend)
 {
     int err = ps_new_stdlib_malloc_ops(&ops.malloc_ops);
     ZF_LOGF_IF(err, "Failed to get malloc ops");

--- a/libsel4vmmplatsupport/src/drivers/virtio_vsock.c
+++ b/libsel4vmmplatsupport/src/drivers/virtio_vsock.c
@@ -44,10 +44,11 @@ static int virtio_vsock_io_out(void *cookie, unsigned int port_no, unsigned int 
 }
 
 
-static int emul_vsock_driver_init(struct vsock_passthrough *driver, ps_io_ops_t io_ops, void *config)
+static int emul_vsock_driver_init(struct virtio_vsock_driver *driver, ps_io_ops_t io_ops, void *config)
 {
     virtio_vsock_t *vsock = (virtio_vsock_t *) config;
-    *driver = vsock->emul_driver_funcs;
+    driver->backend_fn = vsock->emul_driver_funcs;
+    vsock->emul_driver = driver;
     return 0;
 }
 
@@ -91,7 +92,7 @@ static vmm_pci_entry_t vmm_virtio_vsock_pci_bar(unsigned int iobase, size_t ioba
 
 virtio_vsock_t *common_make_virtio_vsock(vm_t *vm, vmm_pci_space_t *pci, vmm_io_port_list_t *ioport,
                                          ioport_range_t ioport_range, ioport_type_t port_type, unsigned int interrupt_pin, unsigned int interrupt_line,
-                                         struct vsock_passthrough backend)
+                                         struct virtio_vsock_passthrough backend)
 {
     int err = ps_new_stdlib_malloc_ops(&ops.malloc_ops);
     ZF_LOGF_IF(err, "Failed to get malloc ops");


### PR DESCRIPTION
- make emul_con_rx_complete deal with ring buffers to avoid an extra copy of the buffer from the virtio console backend to the emul layer. Previous discussion: https://github.com/seL4/camkes-vm/pull/36#discussion_r1019800073

- small refactor for virtio vsock and virtio console. Previous discussion: https://github.com/seL4/camkes-vm/pull/36#discussion_r1045428300

- depends on: https://github.com/seL4/camkes-vm/pull/36
