### PR TITLE
trivial: revert Copyright headers

### DIFF
--- a/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio.h
+++ b/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, UNSW (ABN 57 195 873 179)
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_pci_console.h
+++ b/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_pci_console.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, UNSW (ABN 57 195 873 179)
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_pci_emul.h
+++ b/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/virtio_pci_emul.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, UNSW (ABN 57 195 873 179)
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/libsel4vmmplatsupport/src/drivers/virtio_console_emul.c
+++ b/libsel4vmmplatsupport/src/drivers/virtio_console_emul.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, UNSW (ABN 57 195 873 179)
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/libsel4vmmplatsupport/src/drivers/virtio_emul.c
+++ b/libsel4vmmplatsupport/src/drivers/virtio_emul.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, UNSW (ABN 57 195 873 179)
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/libsel4vmmplatsupport/src/drivers/virtio_net_emul.c
+++ b/libsel4vmmplatsupport/src/drivers/virtio_net_emul.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022, UNSW (ABN 57 195 873 179)
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */


### PR DESCRIPTION
Fix the Copyright headers that have been altered incorrectly in a previous [PR](https://github.com/seL4/seL4_projects_libs/pull/74#issuecomment-1328653368).