### PR TITLE
libsel4vmmplatsupport: remove superfluous statement

### DIFF
--- a/libsel4vmmplatsupport/src/arch/arm/guest_image.c
+++ b/libsel4vmmplatsupport/src/arch/arm/guest_image.c
@@ -103,12 +103,7 @@ uintptr_t zImage_get_load_address(void *file, uintptr_t ram_base)
 {
     struct zimage_hdr *hdr;
     hdr = (struct zimage_hdr *)file;
-    if (hdr->start == 0) {
-        return ram_base + 0x8000;
-    } else {
-        return hdr->start;
-    }
-    return 0;
+    return (hdr->start != 0) ? hdr->start : (ram_base + 0x8000);
 }
 
 static int get_guest_image_type(const char *image_name, enum img_type *image_type, Elf64_Ehdr *header)


### PR DESCRIPTION
The last return statement is never reached.

Note that I think the `ram_base + 0x8000` might be wrong also and should also become  `vm->entry` now. But I will address this in a later PR then after more testing (https://github.com/Hensoldt-Cyber/seL4_projects_libs/commits/patch-axel-26a). It seems that zImage is no longer used for 64-bit anyway.