### PR TITLE
libsel4vm: Adhere to gnu99 static assertion

### DIFF
--- a/libsel4vm/src/arch/arm/vgic/virq.h
+++ b/libsel4vm/src/arch/arm/vgic/virq.h
@@ -8,6 +8,8 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <utils/util.h>
+
 #include "vm.h"
 
 
@@ -52,8 +54,8 @@ static inline void virq_ack(vm_vcpu_t *vcpu, struct virq_handle *irq)
 #define MAX_IRQ_QUEUE_LEN 64
 #define IRQ_QUEUE_NEXT(_i) (((_i) + 1) & (MAX_IRQ_QUEUE_LEN - 1))
 
-static_assert((MAX_IRQ_QUEUE_LEN & (MAX_IRQ_QUEUE_LEN - 1)) == 0,
-              "IRQ ring buffer size must be power of two");
+compile_time_assert("IRQ ring buffer size must be power of two",
+                    (MAX_IRQ_QUEUE_LEN & (MAX_IRQ_QUEUE_LEN - 1)) == 0);
 
 struct irq_queue {
     struct virq_handle *irqs[MAX_IRQ_QUEUE_LEN]; /* circular buffer */


### PR DESCRIPTION
static_assert was standardized in C11 as a macro prior C23. While _Static_assert was introduced to C11 standard too, it's been part of GNU extensions and is available for GNU flavored standards prior C11.

Fixes compilation error on some versions of gcc.