### PR TITLE
Cross-connector: use dataport frame size instead of 4k default

### DIFF
--- a/libsel4vm/docs/libsel4vm_guest_memory.md
+++ b/libsel4vm/docs/libsel4vm_guest_memory.md
@@ -26,6 +26,8 @@ The user can then further back the reservation with seL4 frames by performing `v
 
 > [`vm_map_reservation(vm, reservation, map_iterator, cookie)`](#function-vm_map_reservationvm-reservation-map_iterator-cookie)
 
+> [`vm_map_reservation_frames(vm, reservation, frames, num_frames, frame_size_bits)`](#function-vm_map_reservationvm-reservation-frames-num_frames-frame_size_bits)
+
 > [`vm_get_reservation_memory_region(reservation, addr, size)`](#function-vm_get_reservation_memory_regionreservation-addr-size)
 
 > [`vm_memory_init(vm)`](#function-vm_memory_initvm)
@@ -104,6 +106,24 @@ Map a reservation into the VM's virtual address space
 - `reservation {vm_memory_reservation_t *}`: Pointer to reservation object being mapped
 - `map_iterator {memory_map_iterator_fn}`: Iterator function that returns a cap to the memory region being mapped
 - `cookie {void *}`: Cookie to pass onto map_iterator function
+
+**Returns:**
+
+- -1 on failure otherwise 0 for success
+
+Back to [interface description](#module-guest_memoryh).
+
+### Function `vm_map_reservation_frames(vm, reservation, frames, num_frames, frame_size_bits)`
+
+Map a reservation into the VM's virtual address space from given frames
+
+**Parameters:**
+
+- `vm {vm_t *}`: A handle to the VM
+- `reservation {vm_memory_reservation_t *}`: Pointer to reservation object being mapped
+- `frames {seL4_CPtr *}`: Array of frame caps
+- `num_frames {size_t}`: Number of frame caps
+- `frame_size_bits {size_t}`: Bit size of a single frame
 
 **Returns:**
 

--- a/libsel4vm/include/sel4vm/guest_memory.h
+++ b/libsel4vm/include/sel4vm/guest_memory.h
@@ -135,6 +135,20 @@ int vm_map_reservation(vm_t *vm, vm_memory_reservation_t *reservation, memory_ma
                        void *cookie);
 
 /***
+ * @function vm_map_reservation_frames(vm, reservation, frames, num_frames, frame_size_bits)
+ * Map a reservation into the VM's virtual address space from given frames
+ * @param {vm_t *} vm                                   A handle to the VM
+ * @param {vm_memory_reservation_t *} reservation       Pointer to reservation object being mapped
+ * @param {seL4_CPtr *} frames                          Array of frame caps
+ * @param {size_t} num_frames                           Number of frame caps
+ * @param {size_t} frame_size_bits                      Bit size of a single frame
+ * @return                                              -1 on failure otherwise 0 for success
+ */
+int vm_map_reservation_frames(vm_t *vm, vm_memory_reservation_t *reservation,
+                              seL4_CPtr *frames, size_t num_frames,
+                              size_t frame_size_bits);
+
+/***
  * @function vm_get_reservation_memory_region(reservation, addr, size)
  * Get the memory region information (address & size) from a given reservation
  * @param {vm_memory_reservation_t *} reservation           Pointer to reservation object

--- a/libsel4vm/src/guest_memory.c
+++ b/libsel4vm/src/guest_memory.c
@@ -60,6 +60,13 @@ typedef struct res_tree {
     struct res_tree *right;
 } res_tree;
 
+struct frames_map_iterator_cookie {
+    seL4_CPtr *frames;
+    size_t num_frames;
+    size_t frame_size_bits;
+    uintptr_t start;
+};
+
 static inline int reservation_node_cmp(res_tree *x, res_tree *y)
 {
     if (x->addr < y->addr) {
@@ -513,6 +520,39 @@ int vm_map_reservation(vm_t *vm, vm_memory_reservation_t *reservation,
     }
 
     return 0;
+}
+
+static vm_frame_t frames_map_memory_iterator(uintptr_t page_start, void *cookie)
+{
+    vm_frame_t frame_result = { seL4_CapNull, seL4_NoRights, 0, 0 };
+    struct frames_map_iterator_cookie *it = cookie;
+
+    size_t frame_idx = (page_start - it->start) >> it->frame_size_bits;
+    if (frame_idx >= it->num_frames) {
+        return frame_result;
+    }
+
+    frame_result.cptr = it->frames[frame_idx];
+    frame_result.rights = seL4_AllRights;
+    frame_result.vaddr = page_start;
+    frame_result.size_bits = it->frame_size_bits;
+
+    return frame_result;
+}
+
+int vm_map_reservation_frames(vm_t *vm, vm_memory_reservation_t *reservation,
+                              seL4_CPtr *frames, size_t num_frames,
+                              size_t frame_size_bits)
+{
+    struct frames_map_iterator_cookie cookie = {
+        .frames = frames,
+        .num_frames = num_frames,
+        .frame_size_bits = frame_size_bits,
+        .start = reservation->addr,
+    };
+
+    return vm_map_reservation(vm, reservation, frames_map_memory_iterator,
+                              &cookie);
 }
 
 void vm_get_reservation_memory_region(vm_memory_reservation_t *reservation, uintptr_t *addr, size_t *size)

--- a/libsel4vm/src/guest_ram.c
+++ b/libsel4vm/src/guest_ram.c
@@ -323,7 +323,9 @@ uintptr_t vm_ram_register(vm_t *vm, size_t bytes)
     int err;
     uintptr_t base_addr;
 
-    ram_reservation = vm_reserve_anon_memory(vm, bytes, 0x1000, default_ram_fault_callback, NULL, &base_addr);
+    ram_reservation = vm_reserve_anon_memory(vm, bytes, BIT(seL4_PageBits),
+                                             default_ram_fault_callback, NULL,
+                                             &base_addr);
     if (!ram_reservation) {
         ZF_LOGE("Unable to reserve ram region of size 0x%zx", bytes);
         return 0;

--- a/libsel4vmmplatsupport/src/drivers/cross_vm_connection.c
+++ b/libsel4vmmplatsupport/src/drivers/cross_vm_connection.c
@@ -301,8 +301,6 @@ static int initialise_connections(vm_t *vm, uintptr_t connection_base_addr, cros
 int cross_vm_connections_init_common(vm_t *vm, uintptr_t connection_base_addr, crossvm_handle_t *connections,
                                      int num_connections, vmm_pci_space_t *pci, alloc_free_interrupt_fn alloc_irq)
 {
-    uintptr_t guest_paddr = 0;
-    size_t guest_size = 0;
     if (num_connections > MAX_NUM_CONNECTIONS) {
         ZF_LOGE("Unable to register more than %d dataports", MAX_NUM_CONNECTIONS);
         return -1;

--- a/libsel4vmmplatsupport/src/drivers/cross_vm_connection.c
+++ b/libsel4vmmplatsupport/src/drivers/cross_vm_connection.c
@@ -48,8 +48,8 @@ struct dataport_iterator_cookie {
     vm_t *vm;
 };
 
-struct connection_info info[MAX_NUM_CONNECTIONS];
-int total_connections;
+static struct connection_info info[MAX_NUM_CONNECTIONS];
+static int total_connections;
 
 static int construct_connection_bar(vm_t *vm, struct connection_info *info, int num_connections, vmm_pci_space_t *pci)
 {

--- a/libsel4vmmplatsupport/src/drivers/cross_vm_connection.c
+++ b/libsel4vmmplatsupport/src/drivers/cross_vm_connection.c
@@ -188,6 +188,12 @@ static int reserve_dataport_memory(vm_t *vm, crossvm_dataport_handle_t *dataport
     vm_memory_reservation_t *dataport_reservation = vm_reserve_memory_at(vm, dataport_address, size,
                                                                          default_error_fault_callback,
                                                                          NULL);
+    if (!dataport_reservation) {
+        ZF_LOGE("Cannot reserve %zu bytes at 0x%"PRIxPTR, size,
+                dataport_address);
+        return -1;
+    }
+
     struct dataport_iterator_cookie *dataport_cookie = malloc(sizeof(struct dataport_iterator_cookie));
     if (!dataport_cookie) {
         ZF_LOGE("Failed to allocate dataport iterator cookie");

--- a/libsel4vmmplatsupport/src/guest_memory_util.c
+++ b/libsel4vmmplatsupport/src/guest_memory_util.c
@@ -176,8 +176,9 @@ void *create_allocated_reservation_frame(vm_t *vm, uintptr_t addr, seL4_CapRight
     }
 
     /* Reserve emulated vm frame */
-    cookie->reservation = vm_reserve_memory_at(vm, addr, PAGE_SIZE_4K,
-                                               alloc_fault_callback, (void *)alloc_fault_cookie);
+    cookie->reservation = vm_reserve_memory_at(vm, addr, BIT(page_size),
+                                               alloc_fault_callback,
+                                               (void *)alloc_fault_cookie);
     if (!cookie->reservation) {
         ZF_LOGE("Failed to create allocated vm frame: Unable to reservate emulated frame");
         ps_free(&ops->malloc_ops, sizeof(struct device_frame_cookie), (void **)&cookie);


### PR DESCRIPTION
The main reason for this change set is to support 2 MB and bigger CAmkES dataports. The tooling generates as large as possible frames for dataports, and for example on aarch64 the next step is 2 MB large page. However, the code deals only with 4 kB small pages. Let's use dataport's frame size instead of that default.