### PR TITLE
libsel4vmmplatsupport: reduce log level

### DIFF
--- a/libsel4vmmplatsupport/src/ioports.c
+++ b/libsel4vmmplatsupport/src/ioports.c
@@ -54,7 +54,7 @@ int emulate_io_handler(vmm_io_port_list_t *io_port, unsigned int port_no, bool i
         return -1;
     }
 
-    ZF_LOGI("exit io request: in %d  port no 0x%x (%s) size %d",
+    ZF_LOGD("exit io request: in %d  port no 0x%x (%s) size %d",
             is_in, port_no, vmm_debug_io_portno_desc(io_port, port_no), size);
 
     ioport_entry_t **res_port = search_port(io_port, port_no);


### PR DESCRIPTION
Turn log level for io access to debug as this gets quite annoying when using the vm.