### PR TITLE
cross_vm_connectors: Derive size properly

### DIFF
--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_cross_vm_connection.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_cross_vm_connection.md
@@ -80,7 +80,7 @@ Datastructure representing a dataport of a crossvm connection
 
 **Elements:**
 
-- `size {size_t}`: The size of the crossvm dataport
+- `frame_size_bits {size_t}`: Bit size of a single frame in the `frames` member
 - `num_frames {int}`: Total number of frames in the `frames` member
 - `frames {seL4_CPtr *}`: The set of frames backing the dataport
 

--- a/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/cross_vm_connection.h
+++ b/libsel4vmmplatsupport/include/sel4vmmplatsupport/drivers/cross_vm_connection.h
@@ -27,12 +27,12 @@ typedef int (*alloc_free_interrupt_fn)(void);
 /***
  * @struct crossvm_dataport_handle
  * Datastructure representing a dataport of a crossvm connection
- * @param {size_t} size         The size of the crossvm dataport
- * @param {int} num_frames      Total number of frames in the `frames` member
- * @param {seL4_CPtr *} frames  The set of frames backing the dataport
+ * @param {size_t} frame_size_bits  Bit size of a single frame in the `frames` member
+ * @param {int} num_frames          Total number of frames in the `frames` member
+ * @param {seL4_CPtr *} frames      The set of frames backing the dataport
  */
 typedef struct crossvm_dataport_handle {
-    size_t size;
+    size_t frame_size_bits;
     unsigned int num_frames;
     seL4_CPtr *frames;
 } crossvm_dataport_handle_t;


### PR DESCRIPTION
Missing piece for #100 

Also fixes build problem introduced by seL4/camkes-vm#97