### PR TITLE
Make convenience function publicly available

### DIFF
--- a/libsel4vmmplatsupport/include/sel4vmmplatsupport/fdt_utils.h
+++ b/libsel4vmmplatsupport/include/sel4vmmplatsupport/fdt_utils.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023, Technology Innovation Institute
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <libfdt.h>
+
+/**
+ * fdt_appendprop_uint - append a 32-bit or a 64-bit integer value to a property
+ * @fdt: pointer to the device tree blob
+ * @offset: offset of the node whose property to change
+ * @name: name of the property to change
+ * @val: integer value to append to the property (native endian)
+ * @num_cells: typically fdt_address_cells() or fdt_size_cells() of parent node
+ * @return -1 on error, 0 otherwise
+ *
+ * fdt_appendprop_uint() is a wrapper calling either fdt_appendprop_u32() or
+ * fdt_appendprop_u64(), whether num_cells is 1 or 2, respectively. Hence
+ * consult the documentation of those functions for return values. In case
+ * num_cells is invalid, -FDT_ERR_BADNCELLS is returned.
+ */
+int fdt_appendprop_uint(void *fdt, int offset, const char *name, uint64_t val,
+                        int num_cells);

--- a/libsel4vmmplatsupport/src/arch/arm/devices/vpci.c
+++ b/libsel4vmmplatsupport/src/arch/arm/devices/vpci.c
@@ -16,6 +16,7 @@
 #include <sel4vm/guest_vm.h>
 #include <sel4vm/guest_vcpu_fault.h>
 
+#include <sel4vmmplatsupport/fdt_utils.h>
 #include <sel4vmmplatsupport/drivers/pci_helper.h>
 #include <sel4vmmplatsupport/drivers/pci.h>
 #include <sel4vmmplatsupport/ioports.h>
@@ -208,21 +209,6 @@ int vm_install_vpci(vm_t *vm, vmm_io_port_list_t *io_port, vmm_pci_space_t *pci)
     return 0;
 }
 
-static int append_prop_with_cells(void *fdt, int offset,  uint64_t val, int num_cells, const char *name)
-{
-    int err;
-    if (num_cells == 2) {
-        err = fdt_appendprop_u64(fdt, offset, name, val);
-    } else if (num_cells == 1) {
-        err = fdt_appendprop_u32(fdt, offset, name, val);
-    } else {
-        ZF_LOGE("non-supported arch");
-        err = -1;
-    }
-
-    return err;
-}
-
 int fdt_generate_vpci_node(vm_t *vm, vmm_pci_space_t *pci, void *fdt, int gic_phandle)
 {
     int err;
@@ -236,18 +222,18 @@ int fdt_generate_vpci_node(vm_t *vm, vmm_pci_space_t *pci, void *fdt, int gic_ph
     }
 
     /* Basic PCI Properties*/
-    FDT_OP(append_prop_with_cells(fdt, pci_node, 0x3, 1, "#address-cells"));
-    FDT_OP(append_prop_with_cells(fdt, pci_node, 0x2, 1, "#size-cells"));
-    FDT_OP(append_prop_with_cells(fdt, pci_node, 0x1, 1, "#interrupt-cells"));
+    FDT_OP(fdt_appendprop_u32(fdt, pci_node, "#address-cells", 0x3));
+    FDT_OP(fdt_appendprop_u32(fdt, pci_node, "#size-cells", 0x2));
+    FDT_OP(fdt_appendprop_u32(fdt, pci_node, "#interrupt-cells", 0x1));
     FDT_OP(fdt_appendprop_string(fdt, pci_node, "compatible", "pci-host-cam-generic"));
     FDT_OP(fdt_appendprop_string(fdt, pci_node, "device_type", "pci"));
     FDT_OP(fdt_appendprop(fdt, pci_node, "dma-coherent", NULL, 0));
-    FDT_OP(append_prop_with_cells(fdt, pci_node, 0x0, 1, "bus-range"));
-    FDT_OP(append_prop_with_cells(fdt, pci_node, 0x1, 1, "bus-range"));
+    FDT_OP(fdt_appendprop_u32(fdt, pci_node, "bus-range", 0x0));
+    FDT_OP(fdt_appendprop_u32(fdt, pci_node, "bus-range", 0x1));
 
     /* PCI Host CFG Region */
-    FDT_OP(append_prop_with_cells(fdt, pci_node, PCI_CFG_REGION_ADDR, address_cells, "reg"));
-    FDT_OP(append_prop_with_cells(fdt, pci_node, PCI_CFG_REGION_SIZE, size_cells, "reg"));
+    FDT_OP(fdt_appendprop_uint(fdt, pci_node, "reg", PCI_CFG_REGION_ADDR, address_cells));
+    FDT_OP(fdt_appendprop_uint(fdt, pci_node, "reg", PCI_CFG_REGION_SIZE, size_cells));
 
     /* PCI IO Region Range */
     struct pci_fdt_address pci_io_range_addr;
@@ -255,7 +241,7 @@ int fdt_generate_vpci_node(vm_t *vm, vmm_pci_space_t *pci, void *fdt, int gic_ph
     pci_io_range_addr.mid = 0;
     pci_io_range_addr.low = 0;
     FDT_OP(fdt_appendprop(fdt, pci_node, "ranges", &pci_io_range_addr, sizeof(struct pci_fdt_address)));
-    FDT_OP(append_prop_with_cells(fdt, pci_node, PCI_IO_REGION_ADDR, address_cells, "ranges"));
+    FDT_OP(fdt_appendprop_uint(fdt, pci_node, "ranges", PCI_IO_REGION_ADDR, address_cells));
     FDT_OP(fdt_appendprop_u64(fdt, pci_node, "ranges", PCI_IO_REGION_SIZE));
 
     /* PCI Mem Region Range */
@@ -264,7 +250,7 @@ int fdt_generate_vpci_node(vm_t *vm, vmm_pci_space_t *pci, void *fdt, int gic_ph
     pci_mem_range_addr.mid = cpu_to_fdt32(PCI_MEM_REGION_ADDR >> 32);
     pci_mem_range_addr.low = cpu_to_fdt32((uint32_t)PCI_MEM_REGION_ADDR);
     FDT_OP(fdt_appendprop(fdt, pci_node, "ranges", &pci_mem_range_addr, sizeof(pci_mem_range_addr)));
-    FDT_OP(append_prop_with_cells(fdt, pci_node, PCI_MEM_REGION_ADDR, address_cells, "ranges"));
+    FDT_OP(fdt_appendprop_uint(fdt, pci_node, "ranges", PCI_MEM_REGION_ADDR, address_cells));
     FDT_OP(fdt_appendprop_u64(fdt, pci_node, "ranges", PCI_MEM_REGION_SIZE));
 
     /* PCI IRQ map */

--- a/libsel4vmmplatsupport/src/fdt_utils.c
+++ b/libsel4vmmplatsupport/src/fdt_utils.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019, Data61, CSIRO (ABN 41 687 119 230)
+ * Copyright 2023, Technology Innovation Institute
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <sel4vmmplatsupport/fdt_utils.h>
+
+#include <libfdt.h>
+#include <utils/util.h>
+
+int fdt_appendprop_uint(void *fdt, int offset, const char *name, uint64_t val,
+                        int num_cells)
+{
+    int err;
+    if (num_cells == 2) {
+        err = fdt_appendprop_u64(fdt, offset, name, val);
+    } else if (num_cells == 1) {
+        err = fdt_appendprop_u32(fdt, offset, name, val);
+    } else {
+        ZF_LOGE("invalid number of cells (%d)", num_cells);
+        err = -FDT_ERR_BADNCELLS;
+    }
+
+    return err;
+}


### PR DESCRIPTION
Also align with naming and argument order style used in libfdt.

Test with: seL4/camkes-vm#103