### PR TITLE
libsel4vm: fix GIC_DIST_CTLR enable handling

### DIFF
--- a/libsel4vm/src/arch/arm/vgic/vdist.h
+++ b/libsel4vm/src/arch/arm/vgic/vdist.h
@@ -425,13 +425,15 @@ static memory_fault_result_t vgic_dist_reg_write(vm_t *vm, vm_vcpu_t *vcpu,
     switch (offset) {
     case RANGE32(GIC_DIST_CTLR, GIC_DIST_CTLR):
         data = fault_get_data(fault);
-        if (data == 1) {
+        if (data & GIC_DIST_CTLR_EN_GRP0) {
             vgic_dist_enable(vgic, vm);
-        } else if (data == 0) {
-            vgic_dist_disable(vgic, vm);
         } else {
-            ZF_LOGE("Unknown enable register encoding");
+            vgic_dist_disable(vgic, vm);
         }
+        ZF_LOGW_IF(data & GIC_DIST_CTLR_EN_GRP1,
+                   "ignore bit EnableGrp1 in DIST_CTLR write");
+        ZF_LOGE_IF(data & ~(GIC_DIST_CTLR_EN_GRP0 | GIC_DIST_CTLR_EN_GRP1),
+                   "ignore unknown bits in DIST_CTLR write 0x%x", data);
         break;
     case RANGE32(GIC_DIST_TYPER, GIC_DIST_TYPER):
         break;

--- a/libsel4vm/src/arch/arm/vgic/vgicv2_defs.h
+++ b/libsel4vm/src/arch/arm/vgic/vgicv2_defs.h
@@ -68,3 +68,6 @@
 #define GIC_DIST_SGI_CPU_TARGET_LIST_MASK       0xFF << GIC_DIST_SGI_CPU_TARGET_LIST_SHIFT
 
 #define GIC_DIST_SGI_INTID_MASK                 0xF
+
+#define GIC_DIST_CTLR_EN_GRP0                   (1U << 0)
+#define GIC_DIST_CTLR_EN_GRP1                   (1U << 1)


### PR DESCRIPTION
We have seen that some VMs try to write `0x03` instead of `0x01`. Support this case more gracefully and ensure that the `GIC_DIST_CTLR_EN_GRP1` setting properly applied.

- check the bit an not the value
- ignore GIC_DIST_CTLR_EN_GRP1 and print a warning
- print the value if unknown bits are set