### PR TITLE
64-bit-vms: small code refactoring

### DIFF
--- a/libsel4vm/arch_include/x86/sel4vm/arch/guest_x86_context.h
+++ b/libsel4vm/arch_include/x86/sel4vm/arch/guest_x86_context.h
@@ -24,7 +24,7 @@ typedef enum vcpu_context_reg {
     VCPU_CONTEXT_ESI,
     VCPU_CONTEXT_EDI,
     VCPU_CONTEXT_EBP,
-#ifdef CONFIG_ARCH_X86_64
+#ifdef CONFIG_X86_64_VTX_64BIT_GUESTS
     VCPU_CONTEXT_R8,
     VCPU_CONTEXT_R9,
     VCPU_CONTEXT_R10,
@@ -33,7 +33,7 @@ typedef enum vcpu_context_reg {
     VCPU_CONTEXT_R13,
     VCPU_CONTEXT_R14,
     VCPU_CONTEXT_R15
-#endif
+#endif /* CONFIG_X86_64_VTX_64BIT_GUESTS */
 } vcpu_context_reg_t;
 
 /***

--- a/libsel4vm/src/arch/x86/boot.c
+++ b/libsel4vm/src/arch/x86/boot.c
@@ -37,7 +37,7 @@
 /* We need to own the PSE and PAE bits up until the guest has actually turned on paging,
  * then it can control them
  */
-#ifdef CONFIG_ARCH_X86_64
+#ifdef CONFIG_X86_64_VTX_64BIT_GUESTS
 #define VM_VMCS_CR4_MASK           (X86_CR4_VMXE)
 #define VM_VMCS_CR4_VALUE          (X86_CR4_PAE)
 #else
@@ -126,7 +126,7 @@ static int make_guest_pdpt_continued(void *access_addr, void *vaddr, void *cooki
 
 static int make_guest_root_pd_continued(void *access_addr, void *vaddr, void *cookie)
 {
-#ifdef CONFIG_ARCH_X86_64
+#ifdef CONFIG_X86_64_VTX_64BIT_GUESTS
     assert(NULL != cookie);
 
     vm_t *vm = (vm_t *)cookie;
@@ -156,14 +156,14 @@ static int make_guest_root_pd_continued(void *access_addr, void *vaddr, void *co
     if (error) {
         return error;
     }
-#else
+#else /* not CONFIG_X86_64_VTX_64BIT_GUESTS */
     /* Write into this frame as the init page directory: 4M pages, 1 to 1 mapping. */
     uint32_t *pd = vaddr;
     for (int i = 0; i < 1024; i++) {
         /* Present, write, user, page size 4M */
         pd[i] = (i << PAGE_BITS_4M) | PAGE_ENTRY;
     }
-#endif
+#endif /* CONFIG_X86_64_VTX_64BIT_GUESTS */
     return 0;
 }
 
@@ -189,9 +189,9 @@ static int make_guest_address_space(vm_t *vm)
 
     void *cookie = NULL;
 
-#ifdef CONFIG_ARCH_X86_64
+#ifdef CONFIG_X86_64_VTX_64BIT_GUESTS
     cookie = (void *) vm;
-#endif
+#endif /* CONFIG_X86_64_VTX_64BIT_GUESTS */
     return vspace_access_page_with_callback(&vm->mem.vm_vspace, &vm->mem.vmm_vspace,
                                             (void *)GUEST_VSPACE_ROOT,
                                             seL4_PageBits, seL4_AllRights, 1,

--- a/libsel4vm/src/arch/x86/guest_state.h
+++ b/libsel4vm/src/arch/x86/guest_state.h
@@ -100,7 +100,7 @@ typedef enum guest_user_context {
     USER_CONTEXT_ESI,
     USER_CONTEXT_EDI,
     USER_CONTEXT_EBP,
-#ifdef CONFIG_ARCH_X86_64
+#ifdef CONFIG_X86_64_VTX_64BIT_GUESTS
     USER_CONTEXT_R8,
     USER_CONTEXT_R9,
     USER_CONTEXT_R10,
@@ -109,7 +109,7 @@ typedef enum guest_user_context {
     USER_CONTEXT_R13,
     USER_CONTEXT_R14,
     USER_CONTEXT_R15,
-#endif
+#endif /* CONFIG_X86_64_VTX_64BIT_GUESTS */
     NUM_USER_CONTEXT_REGS
 } guest_user_context_t;
 

--- a/libsel4vm/src/arch/x86/processor/decode.c
+++ b/libsel4vm/src/arch/x86/processor/decode.c
@@ -499,7 +499,7 @@ uintptr_t vm_emulate_realmode(vm_vcpu_t *vcpu, uint8_t *instr_buf,
             case 0xa1:
                 /* mov offset memory to eax */
                 instr++;
-#ifdef CONFIG_ARCH_X86_64
+#ifdef CONFIG_X86_64_VTX_64BIT_GUESTS
                 memcpy(&mem, instr, 4);
                 instr += 4;
 #else


### PR DESCRIPTION
switch from `CONFIG_ARCH_X86_64` to `CONFIG_X86_64_VTX_64BIT_GUESTS` to allow 32 bit guests on 64 bit hosts.

This commit contains pieces that I omitted in the previous [code refactor](https://github.com/seL4/seL4_projects_libs/pull/16/commits/8227e006f50fbe981a1ce3791da5e11386c65bf5), and should be able to fix the [test failures](https://github.com/seL4/camkes-vm-examples/actions/runs/5273212619/jobs/9536500187).