### PR TITLE
sel4vm, lapic: fix apic mmio access

### DIFF
--- a/libsel4vm/src/arch/x86/processor/lapic.c
+++ b/libsel4vm/src/arch/x86/processor/lapic.c
@@ -872,11 +872,11 @@ memory_fault_result_t apic_fault_callback(vm_t *vm, vm_vcpu_t *vcpu, uintptr_t f
 {
     seL4_Word data;
     if (is_vcpu_read_fault(vcpu)) {
-        vm_apic_mmio_read(vcpu, cookie, APIC_DEFAULT_PHYS_BASE - fault_addr, fault_length, &data);
+        vm_apic_mmio_read(vcpu, cookie, fault_addr - APIC_DEFAULT_PHYS_BASE, fault_length, &data);
         set_vcpu_fault_data(vcpu, data);
     } else {
         data = get_vcpu_fault_data(vcpu);
-        vm_apic_mmio_write(vcpu, cookie, APIC_DEFAULT_PHYS_BASE - fault_addr, fault_length, data);
+        vm_apic_mmio_write(vcpu, cookie, fault_addr - APIC_DEFAULT_PHYS_BASE, fault_length, data);
     }
     advance_vcpu_fault(vcpu);
     return FAULT_HANDLED;


### PR DESCRIPTION
The subtraction is backwards, so lapic access will never work.