### PR TITLE
vmmplatsupport, vesa: fix vesa mapping

### DIFF
--- a/libsel4vmmplatsupport/CMakeLists.txt
+++ b/libsel4vmmplatsupport/CMakeLists.txt
@@ -65,4 +65,5 @@ target_link_libraries(
     sel4_autoconf
     sel4vm_Config
     usbdrivers_Config
+    sel4vmmplatsupport_Config
 )


### PR DESCRIPTION
The previous behavior would only attempt to map the vesa framebuffer and set the screen info struct if the vbe protection mode interface was successfully mapped in. This removes the dependency on the vbe protected mode interface. It is not clear that it is needed as vesa framebuffer passthrough works without it.