### PR TITLE
vm_syscall_handler error

### DIFF
--- a/libsel4vm/src/arch/arm/syscalls.c
+++ b/libsel4vm/src/arch/arm/syscalls.c
@@ -120,7 +120,7 @@ int vm_syscall_handler(vm_vcpu_t *vcpu)
 {
     int err;
     err = handle_syscall(vcpu);
-    if (!err) {
+    if (err == VM_EXIT_HANDLED) {
         seL4_MessageInfo_t reply;
         reply = seL4_MessageInfo_new(0, 0, 0, 0);
         seL4_Reply(reply);


### PR DESCRIPTION
err = handle_syscall(vcpu);
If handle_syscall successfully processes, it will return VM_EXIT_HANDLED, which is defined as 1.
if (!err) {
The original condition !err is 0, causing the VM to block after successful processing.
