### PR TITLE
sel4vmmplatsupport: Rename PAGE_SIZE constant

### DIFF
--- a/libsel4vmmplatsupport/src/drivers/cross_vm_connection.c
+++ b/libsel4vmmplatsupport/src/drivers/cross_vm_connection.c
@@ -139,7 +139,7 @@ static int reserve_event_bar(vm_t *vm, uintptr_t event_bar_address, struct conne
         return -1;
     }
     /* Zero out memory */
-    memset(info->event_registers, 0, PAGE_SIZE);
+    memset(info->event_registers, 0, PAGE_SIZE_4K);
     info->event_address = event_bar_address;
     return 0;
 }

--- a/libsel4vmmplatsupport/src/plat/tk1/devices/usb.c
+++ b/libsel4vmmplatsupport/src/plat/tk1/devices/usb.c
@@ -22,7 +22,7 @@
 const struct device dev_usb = {
     .name = "usb",
     .pstart = 0x7d004000,
-    .size = PAGE_SIZE,
+    .size = PAGE_SIZE_4K,
     .priv = NULL
 };
 

--- a/libsel4vmmplatsupport/src/plat/tk1/devices/vclock.c
+++ b/libsel4vmmplatsupport/src/plat/tk1/devices/vclock.c
@@ -11,7 +11,7 @@
 const struct device dev_clkcar = {
     .name = "clkcar",
     .pstart = TK1_CLKCAR_PADDR,
-    .size = PAGE_SIZE,
+    .size = PAGE_SIZE_4K,
     .handle_device_fault = NULL,
     .priv = NULL
 };

--- a/libsel4vmmplatsupport/src/plat/tk1/devices/vuart.c
+++ b/libsel4vmmplatsupport/src/plat/tk1/devices/vuart.c
@@ -12,7 +12,7 @@
 const struct device dev_uartd = {
     .name = "uartd",
     .pstart = UARTD_PADDR,
-    .size = PAGE_SIZE,
+    .size = PAGE_SIZE_4K,
     .handle_device_fault = NULL,
     .priv = NULL
 };


### PR DESCRIPTION
PAGE_SIZE_4K is a constant declared by one of our libraries, while PAGE_SIZE was previously provided by an older fork of the C library.