### PR TITLE
api docs: fix links

### DIFF
--- a/libsel4vm/docs/libsel4vm_arm_guest_vm.md
+++ b/libsel4vm/docs/libsel4vm_arm_guest_vm.md
@@ -40,7 +40,7 @@ Register a callback for processing unhandled vcpu faults
 
 - 0 on success, -1 on error
 
-Back to [interface description](#module-guest_vm_archh).
+Back to [interface description](#interface-guest_vm_archh).
 
 
 ## Structs
@@ -57,7 +57,7 @@ Structure representing ARM specific vcpu properties
 - `unhandled_vcpu_callback {unhandled_vcpu_fault_callback_fn}`: A callback for processing unhandled vcpu faults
 - `unhandled_vcpu_callback_cookie {void *}`: A cookie to supply to the vcpu fault handler
 
-Back to [interface description](#module-guest_vm_archh).
+Back to [interface description](#interface-guest_vm_archh).
 
 
 Back to [top](#).

--- a/libsel4vm/docs/libsel4vm_boot.md
+++ b/libsel4vm/docs/libsel4vm_boot.md
@@ -41,7 +41,7 @@ Initialise/Create VM
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-booth).
+Back to [interface description](#interface-booth).
 
 ### Function `vm_create_vcpu(vm, priority)`
 
@@ -56,7 +56,7 @@ Create a VCPU for a given VM
 
 - NULL for error, otherwise pointer to created vm_vcpu_t object
 
-Back to [interface description](#module-booth).
+Back to [interface description](#interface-booth).
 
 ### Function `vm_assign_vcpu_target(vcpu, target_cpu)`
 
@@ -71,7 +71,7 @@ Assign a vcpu with logical target cpu to run on
 
 - -1 for error, otherwise 0 for success
 
-Back to [interface description](#module-booth).
+Back to [interface description](#interface-booth).
 
 
 Back to [top](#).

--- a/libsel4vm/docs/libsel4vm_guest_arm_context.md
+++ b/libsel4vm/docs/libsel4vm_guest_arm_context.md
@@ -44,7 +44,7 @@ Set a VCPU's thread registers given a TCB user context
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_arm_contexth).
+Back to [interface description](#interface-guest_arm_contexth).
 
 ### Function `vm_set_thread_context_reg(vcpu, reg, value)`
 
@@ -60,7 +60,7 @@ Set a single VCPU's TCB register
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_arm_contexth).
+Back to [interface description](#interface-guest_arm_contexth).
 
 ### Function `vm_get_thread_context(vcpu, context)`
 
@@ -75,7 +75,7 @@ Get a VCPU's TCB user context
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_arm_contexth).
+Back to [interface description](#interface-guest_arm_contexth).
 
 ### Function `vm_get_thread_context_reg(vcpu, reg, value)`
 
@@ -91,7 +91,7 @@ Get a single VCPU's TCB register
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_arm_contexth).
+Back to [interface description](#interface-guest_arm_contexth).
 
 ### Function `vm_set_arm_vcpu_reg(vcpu, reg, value)`
 
@@ -107,7 +107,7 @@ Set an ARM VCPU register
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_arm_contexth).
+Back to [interface description](#interface-guest_arm_contexth).
 
 ### Function `vm_get_arm_vcpu_reg(vcpu, reg, value)`
 
@@ -123,7 +123,7 @@ Get an ARM VCPU register
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_arm_contexth).
+Back to [interface description](#interface-guest_arm_contexth).
 
 
 Back to [top](#).

--- a/libsel4vm/docs/libsel4vm_guest_iospace.md
+++ b/libsel4vm/docs/libsel4vm_guest_iospace.md
@@ -34,7 +34,7 @@ Attach an additional IO space to the given VM
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_iospaceh).
+Back to [interface description](#interface-guest_iospaceh).
 
 
 Back to [top](#).

--- a/libsel4vm/docs/libsel4vm_guest_irq_controller.md
+++ b/libsel4vm/docs/libsel4vm_guest_irq_controller.md
@@ -39,7 +39,7 @@ Inject an IRQ into a VM's interrupt controller
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_irq_controllerh).
+Back to [interface description](#interface-guest_irq_controllerh).
 
 ### Function `vm_set_irq_level(vcpu, irq, irq_level)`
 
@@ -55,7 +55,7 @@ Set level of IRQ number into a VM's interrupt controller
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_irq_controllerh).
+Back to [interface description](#interface-guest_irq_controllerh).
 
 ### Function `vm_register_irq(vcpu, irq, ack_fn, cookie)`
 
@@ -72,7 +72,7 @@ Register irq with an acknowledgment function
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_irq_controllerh).
+Back to [interface description](#interface-guest_irq_controllerh).
 
 ### Function `vm_create_default_irq_controller(vm)`
 
@@ -86,7 +86,7 @@ Install the default interrupt controller into the VM
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_irq_controllerh).
+Back to [interface description](#interface-guest_irq_controllerh).
 
 
 Back to [top](#).

--- a/libsel4vm/docs/libsel4vm_guest_memory.md
+++ b/libsel4vm/docs/libsel4vm_guest_memory.md
@@ -59,7 +59,7 @@ Reserve a region of the VM's memory at a given base address
 
 - NULL on failure otherwise a pointer to a reservation object representing the reserved region
 
-Back to [interface description](#module-guest_memoryh).
+Back to [interface description](#interface-guest_memoryh).
 
 ### Function `vm_reserve_anon_memory(vm, size, align, fault_callback, cookie, addr)`
 
@@ -79,7 +79,7 @@ through the `vm_memory_make_anon` function.
 
 - NULL on failure otherwise a pointer to a reservation object representing the reserved region
 
-Back to [interface description](#module-guest_memoryh).
+Back to [interface description](#interface-guest_memoryh).
 
 ### Function `vm_free_reserved_memory(vm, reservation)`
 
@@ -94,7 +94,7 @@ Free memory reservation from the VM
 
 - -1 on failure otherwise 0 for success
 
-Back to [interface description](#module-guest_memoryh).
+Back to [interface description](#interface-guest_memoryh).
 
 ### Function `vm_map_reservation(vm, reservation, map_iterator, cookie)`
 
@@ -111,7 +111,7 @@ Map a reservation into the VM's virtual address space
 
 - -1 on failure otherwise 0 for success
 
-Back to [interface description](#module-guest_memoryh).
+Back to [interface description](#interface-guest_memoryh).
 
 ### Function `vm_map_reservation_frames(vm, reservation, frames, num_frames, frame_size_bits)`
 
@@ -129,7 +129,7 @@ Map a reservation into the VM's virtual address space from given frames
 
 - -1 on failure otherwise 0 for success
 
-Back to [interface description](#module-guest_memoryh).
+Back to [interface description](#interface-guest_memoryh).
 
 ### Function `vm_get_reservation_memory_region(reservation, addr, size)`
 
@@ -145,7 +145,7 @@ Get the memory region information (address & size) from a given reservation
 
 No return
 
-Back to [interface description](#module-guest_memoryh).
+Back to [interface description](#interface-guest_memoryh).
 
 ### Function `vm_memory_init(vm)`
 
@@ -159,7 +159,7 @@ Initialise a VM's memory management interface
 
 - -1 on failure otherwise 0 for success
 
-Back to [interface description](#module-guest_memoryh).
+Back to [interface description](#interface-guest_memoryh).
 
 
 ## Structs
@@ -177,7 +177,7 @@ Structure representing a mappable memory frame
 - `vaddr {uintptr_t}`: Virtual address of which to map the frame into
 - `size_bits {size_t}`: Size of frame in bits
 
-Back to [interface description](#module-guest_memoryh).
+Back to [interface description](#interface-guest_memoryh).
 
 
 Back to [top](#).

--- a/libsel4vm/docs/libsel4vm_guest_memory_helpers.md
+++ b/libsel4vm/docs/libsel4vm_guest_memory_helpers.md
@@ -36,7 +36,7 @@ Useful to avoid having to re-define a fault callback on regions that should be m
 
 - Always returns FAULT_ERROR
 
-Back to [interface description](#module-guest_memory_helpersh).
+Back to [interface description](#interface-guest_memory_helpersh).
 
 
 Back to [top](#).

--- a/libsel4vm/docs/libsel4vm_guest_ram.md
+++ b/libsel4vm/docs/libsel4vm_guest_ram.md
@@ -53,7 +53,7 @@ Common guest ram touch callback for reading from a guest address into a user sup
 
 - 0 on success, -1 on error
 
-Back to [interface description](#module-guest_ramh).
+Back to [interface description](#interface-guest_ramh).
 
 ### Function `vm_guest_ram_write_callback(vm, guest_addr, vaddr, size, offset, buf)`
 
@@ -72,7 +72,7 @@ Common guest ram touch callback for writing a user supplied buffer into a guest 
 
 - 0 on success, -1 on error
 
-Back to [interface description](#module-guest_ramh).
+Back to [interface description](#interface-guest_ramh).
 
 ### Function `vm_ram_touch(vm, addr, size, touch_callback, cookie)`
 
@@ -90,7 +90,7 @@ Touch a series of pages in the guest vm and invoke a callback for each page acce
 
 - 0 on success, -1 on error
 
-Back to [interface description](#module-guest_ramh).
+Back to [interface description](#interface-guest_ramh).
 
 ### Function `vm_ram_find_largest_free_region(vm, addr, size)`
 
@@ -106,7 +106,7 @@ Find the largest free ram region
 
 - -1 on failure, otherwise 0 for success
 
-Back to [interface description](#module-guest_ramh).
+Back to [interface description](#interface-guest_ramh).
 
 ### Function `vm_ram_register(vm, bytes)`
 
@@ -121,7 +121,7 @@ Reserve a region of memory for RAM in the guest VM
 
 - Starting address of registered ram region
 
-Back to [interface description](#module-guest_ramh).
+Back to [interface description](#interface-guest_ramh).
 
 ### Function `vm_ram_register_at(vm, start, bytes, untyped)`
 
@@ -138,7 +138,7 @@ Reserve a region of memory for RAM in the guest VM at a starting guest physical 
 
 - 0 on success, -1 on error
 
-Back to [interface description](#module-guest_ramh).
+Back to [interface description](#interface-guest_ramh).
 
 ### Function `vm_ram_mark_allocated(vm, start, bytes)`
 
@@ -154,7 +154,7 @@ Mark a registered region of RAM as allocated
 
 No return
 
-Back to [interface description](#module-guest_ramh).
+Back to [interface description](#interface-guest_ramh).
 
 ### Function `vm_ram_allocate(vm, bytes)`
 
@@ -169,7 +169,7 @@ Allocate a region of registered ram
 
 - Starting address of allocated ram region
 
-Back to [interface description](#module-guest_ramh).
+Back to [interface description](#interface-guest_ramh).
 
 ### Function `vm_ram_free(vm, start, bytes)`
 
@@ -185,7 +185,7 @@ Free a RAM a previously allocated RAM region
 
 No return
 
-Back to [interface description](#module-guest_ramh).
+Back to [interface description](#interface-guest_ramh).
 
 
 Back to [top](#).

--- a/libsel4vm/docs/libsel4vm_guest_vcpu_fault.md
+++ b/libsel4vm/docs/libsel4vm_guest_vcpu_fault.md
@@ -51,7 +51,7 @@ Get current fault address of vcpu
 
 - Current fault address of vcpu
 
-Back to [interface description](#module-guest_vcpu_faulth).
+Back to [interface description](#interface-guest_vcpu_faulth).
 
 ### Function `get_vcpu_fault_ip(vcpu)`
 
@@ -65,7 +65,7 @@ Get instruction pointer of current vcpu fault
 
 - Intruction pointer of vcpu fault
 
-Back to [interface description](#module-guest_vcpu_faulth).
+Back to [interface description](#interface-guest_vcpu_faulth).
 
 ### Function `get_vcpu_fault_data(vcpu)`
 
@@ -79,7 +79,7 @@ Get the data of the current vcpu fault
 
 - Data of vcpu fault
 
-Back to [interface description](#module-guest_vcpu_faulth).
+Back to [interface description](#interface-guest_vcpu_faulth).
 
 ### Function `get_vcpu_fault_data_mask(vcpu)`
 
@@ -93,7 +93,7 @@ Get data mask of the current vcpu fault
 
 - Data mask of vcpu fault
 
-Back to [interface description](#module-guest_vcpu_faulth).
+Back to [interface description](#interface-guest_vcpu_faulth).
 
 ### Function `get_vcpu_fault_size(vcpu)`
 
@@ -107,7 +107,7 @@ Get access size of the current vcpu fault
 
 - Access size of vcpu fault
 
-Back to [interface description](#module-guest_vcpu_faulth).
+Back to [interface description](#interface-guest_vcpu_faulth).
 
 ### Function `is_vcpu_read_fault(vcpu)`
 
@@ -121,7 +121,7 @@ Is current vcpu fault a read fault
 
 - True if read fault, False if write fault
 
-Back to [interface description](#module-guest_vcpu_faulth).
+Back to [interface description](#interface-guest_vcpu_faulth).
 
 ### Function `set_vcpu_fault_data(vcpu, data)`
 
@@ -136,7 +136,7 @@ Set the data of the current vcpu fault
 
 - 0 for success, otherwise -1 for error
 
-Back to [interface description](#module-guest_vcpu_faulth).
+Back to [interface description](#interface-guest_vcpu_faulth).
 
 ### Function `emulate_vcpu_fault(vcpu, data)`
 
@@ -151,7 +151,7 @@ Emulate a read or write fault on a given data value
 
 - Emulation result of vcpu fault over given data value
 
-Back to [interface description](#module-guest_vcpu_faulth).
+Back to [interface description](#interface-guest_vcpu_faulth).
 
 ### Function `advance_vcpu_fault(vcpu)`
 
@@ -165,7 +165,7 @@ Advance the current vcpu fault to the next stage/instruction
 
 No return
 
-Back to [interface description](#module-guest_vcpu_faulth).
+Back to [interface description](#interface-guest_vcpu_faulth).
 
 ### Function `restart_vcpu_fault(vcpu)`
 
@@ -179,7 +179,7 @@ Restart the current vcpu fault
 
 No return
 
-Back to [interface description](#module-guest_vcpu_faulth).
+Back to [interface description](#interface-guest_vcpu_faulth).
 
 
 Back to [top](#).

--- a/libsel4vm/docs/libsel4vm_guest_vm.md
+++ b/libsel4vm/docs/libsel4vm_guest_vm.md
@@ -57,7 +57,7 @@ This funtion is a blocking call, returning on the event of an unhandled VM exit 
 
 - 0 on success, -1 on error
 
-Back to [interface description](#module-guest_vmh).
+Back to [interface description](#interface-guest_vmh).
 
 ### Function `vcpu_start(vcpu)`
 
@@ -71,7 +71,7 @@ Start an initialised vcpu thread
 
 - 0 on success, -1 on error
 
-Back to [interface description](#module-guest_vmh).
+Back to [interface description](#interface-guest_vmh).
 
 ### Function `vm_register_unhandled_mem_fault_callback(vm, fault_handler, cookie)`
 
@@ -87,7 +87,7 @@ Register a callback for processing unhandled memory faults (memory regions not p
 
 - 0 on success, -1 on error
 
-Back to [interface description](#module-guest_vmh).
+Back to [interface description](#interface-guest_vmh).
 
 ### Function `vm_register_notification_callback(vm, notification_callback, cookie)`
 
@@ -103,7 +103,7 @@ Register a callback for processing unhandled notifications (events unknown to li
 
 - 0 on success, -1 on error
 
-Back to [interface description](#module-guest_vmh).
+Back to [interface description](#interface-guest_vmh).
 
 
 ## Structs
@@ -120,7 +120,7 @@ Structure representing individual RAM region. A VM can have multiple regions to 
 - `size {size_t}`: Size of region in bytes
 - `allocated {int}`: Whether or not this region has been 'allocated'
 
-Back to [interface description](#module-guest_vmh).
+Back to [interface description](#interface-guest_vmh).
 
 ### Struct `vm_mem`
 
@@ -137,7 +137,7 @@ Structure representing VM memory managment
 - `unhandled_mem_fault_handler {unhandled_mem_fault_callback_fn}`: Registered callback for unhandled memory faults
 - `unhandled_mem_fault_cookie {void *}`: User data passed onto unhandled mem fault callback
 
-Back to [interface description](#module-guest_vmh).
+Back to [interface description](#interface-guest_vmh).
 
 ### Struct `vm_tcb`
 
@@ -149,7 +149,7 @@ Structure used for TCB management within a VCPU
 - `sc {vka_object_t}`: VKA allocated scheduling context
 - `priority {int}`: VCPU scheduling priority
 
-Back to [interface description](#module-guest_vmh).
+Back to [interface description](#interface-guest_vmh).
 
 ### Struct `vm_vcpu`
 
@@ -165,7 +165,7 @@ Structure used to represent a VCPU
 - `vcpu_online {bool}`: Flag representing if the vcpu has been started
 - `vcpu_arch {struct vm_vcpu_arch}`: Architecture specific vcpu properties
 
-Back to [interface description](#module-guest_vmh).
+Back to [interface description](#interface-guest_vmh).
 
 ### Struct `vm_run`
 
@@ -177,7 +177,7 @@ VM Runtime management structure
 - `notification_callback {notification_callback_fn}`: Callback for processing unhandled notifications
 - `notification_callback_cookie {void *}`: A cookie to supply to the notification callback
 
-Back to [interface description](#module-guest_vmh).
+Back to [interface description](#interface-guest_vmh).
 
 ### Struct `vm_cspace`
 
@@ -188,7 +188,7 @@ VM cspace management structure
 - `cspace_obj {vka_object_t}`: VKA allocated cspace object
 - `cspace_root_data {seL4_Word}`: cspace root data capability
 
-Back to [interface description](#module-guest_vmh).
+Back to [interface description](#interface-guest_vmh).
 
 ### Struct `vm`
 
@@ -210,7 +210,7 @@ Structure representing a VM instance
 - `vm_id {unsigned int}`: Identifier for VM. Useful for debugging
 - `vm_initialised {bool}`: Boolean flagging whether VM is intialised or not
 
-Back to [interface description](#module-guest_vmh).
+Back to [interface description](#interface-guest_vmh).
 
 
 Back to [top](#).

--- a/libsel4vm/docs/libsel4vm_guest_vm_util.md
+++ b/libsel4vm/docs/libsel4vm_guest_vm_util.md
@@ -43,7 +43,7 @@ Get the TCB CPtr a given VCPU is associated with
 
 - seL4_CPtr of TCB object
 
-Back to [interface description](#module-guest_vm_utilh).
+Back to [interface description](#interface-guest_vm_utilh).
 
 ### Function `vm_get_vcpu(vm, vcpu_id)`
 
@@ -58,7 +58,7 @@ Get the VCPU CPtr associatated with a given logical ID
 
 - seL4_CapNull if no vcpu exists, otherwise the seL4_CPtr of the VCPU object
 
-Back to [interface description](#module-guest_vm_utilh).
+Back to [interface description](#interface-guest_vm_utilh).
 
 ### Function `vm_vcpu_for_target_cpu(vm, target_cpu)`
 
@@ -73,7 +73,7 @@ Get the VCPU object that is assigned to a given target core ID
 
 - NULL if no vcpu is assigned to the target core, otherwise the vm_vcpu_t object
 
-Back to [interface description](#module-guest_vm_utilh).
+Back to [interface description](#interface-guest_vm_utilh).
 
 ### Function `vm_find_free_unassigned_vcpu(vm)`
 
@@ -87,7 +87,7 @@ Find a VCPU object that hasn't been assigned to a target core
 
 - NULL if no vcpu can be found, otherwise the vm_vcpu_t object
 
-Back to [interface description](#module-guest_vm_utilh).
+Back to [interface description](#interface-guest_vm_utilh).
 
 ### Function `is_vcpu_online(vcpu)`
 
@@ -101,7 +101,7 @@ Find if a given VCPU is online
 
 - True if the vcpu is online, otherwise False
 
-Back to [interface description](#module-guest_vm_utilh).
+Back to [interface description](#interface-guest_vm_utilh).
 
 ### Function `vm_get_vspace(vm)`
 
@@ -115,7 +115,7 @@ Get the vspace of a given VM instance
 
 - A vspace_t object
 
-Back to [interface description](#module-guest_vm_utilh).
+Back to [interface description](#interface-guest_vm_utilh).
 
 ### Function `vm_get_vmm_vspace(vm)`
 
@@ -129,7 +129,7 @@ Get the vspace of the host VMM associated with a given VM instance
 
 - A vspace_t object
 
-Back to [interface description](#module-guest_vm_utilh).
+Back to [interface description](#interface-guest_vm_utilh).
 
 
 Back to [top](#).

--- a/libsel4vm/docs/libsel4vm_guest_x86_context.md
+++ b/libsel4vm/docs/libsel4vm_guest_x86_context.md
@@ -44,7 +44,7 @@ Set a VCPU's thread registers given a seL4_VCPUContext
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_x86_contexth).
+Back to [interface description](#interface-guest_x86_contexth).
 
 ### Function `vm_set_thread_context_reg(vcpu, reg, value)`
 
@@ -60,7 +60,7 @@ Set a single VCPU's thread register in a seL4_VCPUContext
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_x86_contexth).
+Back to [interface description](#interface-guest_x86_contexth).
 
 ### Function `vm_get_thread_context(vcpu, context)`
 
@@ -75,7 +75,7 @@ Get a VCPU's thread context
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_x86_contexth).
+Back to [interface description](#interface-guest_x86_contexth).
 
 ### Function `vm_get_thread_context_reg(vcpu, reg, value)`
 
@@ -91,7 +91,7 @@ Get a single VCPU's thread register
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_x86_contexth).
+Back to [interface description](#interface-guest_x86_contexth).
 
 ### Function `vm_set_vmcs_field(vcpu, field, value)`
 
@@ -107,7 +107,7 @@ Set a VMCS field
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_x86_contexth).
+Back to [interface description](#interface-guest_x86_contexth).
 
 ### Function `vm_get_vmcs_field(vcpu, field, value)`
 
@@ -123,7 +123,7 @@ Get a VMCS register
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-guest_x86_contexth).
+Back to [interface description](#interface-guest_x86_contexth).
 
 
 Back to [top](#).

--- a/libsel4vm/docs/libsel4vm_x86_guest_vm.md
+++ b/libsel4vm/docs/libsel4vm_x86_guest_vm.md
@@ -39,7 +39,7 @@ Structure representing x86 specific vm properties
 - `ioport_list {vm_io_port_list_t}`: List of registered ioport handlers
 - `i8259_gs {i8259_t *}`: PIC machine state
 
-Back to [interface description](#module-guest_vm_archh).
+Back to [interface description](#interface-guest_vm_archh).
 
 ### Struct `vm_vcpu_arch`
 
@@ -50,7 +50,7 @@ Structure representing x86 specific vcpu properties
 - `guest_state {guest_state_t *}`: Current VCPU State
 - `lapic {vm_lapic_t *}`: VM local apic
 
-Back to [interface description](#module-guest_vm_archh).
+Back to [interface description](#interface-guest_vm_archh).
 
 
 Back to [top](#).

--- a/libsel4vm/docs/libsel4vm_x86_ioports.md
+++ b/libsel4vm/docs/libsel4vm_x86_ioports.md
@@ -38,7 +38,7 @@ Add an io port range for emulation
 
 - 0 for success, -1 for error
 
-Back to [interface description](#module-ioportsh).
+Back to [interface description](#interface-ioportsh).
 
 ### Function `vm_register_unhandled_ioport_callback(vm, ioport_callback, cookie)`
 
@@ -54,7 +54,7 @@ Register a callback for processing unhandled ioport faults (faults unknown to li
 
 - 0 for success, -1 for error
 
-Back to [interface description](#module-ioportsh).
+Back to [interface description](#interface-ioportsh).
 
 ### Function `vm_enable_passthrough_ioport(vcpu, port_start, port_end)`
 
@@ -70,7 +70,7 @@ Enable the passing-through of specific ioport ranges to the VM
 
 - 0 for success, -1 for error
 
-Back to [interface description](#module-ioportsh).
+Back to [interface description](#interface-ioportsh).
 
 
 Back to [top](#).

--- a/libsel4vm/docs/libsel4vm_x86_vmcall.md
+++ b/libsel4vm/docs/libsel4vm_x86_vmcall.md
@@ -36,7 +36,7 @@ This being matched with the value found in the vcpu EAX register on a vmcall exc
 
 - 0 on success, -1 on error
 
-Back to [interface description](#module-vmcallh).
+Back to [interface description](#interface-vmcallh).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_ac_device.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_ac_device.md
@@ -47,7 +47,7 @@ guest access.
 
 - 0 on success, -1 on error
 
-Back to [interface description](#module-ac_deviceh).
+Back to [interface description](#interface-ac_deviceh).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_generic_forward_device.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_generic_forward_device.md
@@ -43,7 +43,7 @@ Install the virtual forwarding device into a VM instance
 
 - -1 for error, otherwise 0 for success
 
-Back to [interface description](#module-generic_forward_deviceh).
+Back to [interface description](#interface-generic_forward_deviceh).
 
 
 ## Structs
@@ -59,7 +59,7 @@ Interface for forwarding read and write faults
 - `write_fn {forward_write_fn}`: A callback for forwarding write faults
 - `read_fn {forward_read_fn}`: A callback for forwarding read faults
 
-Back to [interface description](#module-generic_forward_deviceh).
+Back to [interface description](#interface-generic_forward_deviceh).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_guest_boot_init.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_guest_boot_init.md
@@ -56,7 +56,7 @@ FTDs usually contain all necessary information about the machine, so`-1` (`0xfff
 
 - 0 on success, otherwise -1 for failure
 
-Back to [interface description](#module-guest_boot_inith).
+Back to [interface description](#interface-guest_boot_inith).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_guest_reboot.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_guest_reboot.md
@@ -44,7 +44,7 @@ Initialise state of a given reboot hooks list
 
 - 0 for success, otherwise -1 for error
 
-Back to [interface description](#module-guest_rebooth).
+Back to [interface description](#interface-guest_rebooth).
 
 ### Function `vmm_register_reboot_callback(rb_hooks_list, hook, token)`
 
@@ -60,7 +60,7 @@ Register a reboot callback within a given reboot hooks list
 
 - 0 for success, otherwise -1 for error
 
-Back to [interface description](#module-guest_rebooth).
+Back to [interface description](#interface-guest_rebooth).
 
 ### Function `vmm_process_reboot_callbacks(vm, rb_hooks_list)`
 
@@ -75,7 +75,7 @@ Process the reboot hooks registered in a reboot hooks list
 
 - 0 for success, otherwise -1 for error
 
-Back to [interface description](#module-guest_rebooth).
+Back to [interface description](#interface-guest_rebooth).
 
 
 ## Structs
@@ -92,7 +92,7 @@ hook
 - `fn {reboot_hook_fn}`: Function pointer to reboot callback
 - `token {void *}`: Cookie passed to reboot callback when invoked
 
-Back to [interface description](#module-guest_rebooth).
+Back to [interface description](#interface-guest_rebooth).
 
 ### Struct `reboot_hooks_list`
 
@@ -103,7 +103,7 @@ Reboot hooks management datastructure. Contains a list of reboot hooks that a VM
 - `rb_hooks {reboot_hook_t *}`: List of reboot hooks
 - `nhooks {size_t}`: Number of reboot hooks in `rb_hooks` member
 
-Back to [interface description](#module-guest_rebooth).
+Back to [interface description](#interface-guest_rebooth).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_guest_vcpu_fault.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_guest_vcpu_fault.md
@@ -38,7 +38,7 @@ Handle a vcpu exception given the HSR value - Syndrome information
 
 - -1 on error, otherwise 0 for success
 
-Back to [interface description](#module-guest_vcpu_faulth).
+Back to [interface description](#interface-guest_vcpu_faulth).
 
 ### Function `register_arm_vcpu_exception_handler(ec_class, exception_handler)`
 
@@ -53,7 +53,7 @@ Register a handler to a vcpu exception class
 
 No return
 
-Back to [interface description](#module-guest_vcpu_faulth).
+Back to [interface description](#interface-guest_vcpu_faulth).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_guest_vcpu_util.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_guest_vcpu_util.md
@@ -33,7 +33,7 @@ the vcpus created for the VM.
 
 - 0 for success, -1 for error
 
-Back to [interface description](#module-guest_vcpu_utilh).
+Back to [interface description](#interface-guest_vcpu_utilh).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_vpci.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_vpci.md
@@ -38,7 +38,7 @@ The interface `vpci.h` defines the following functions.
 
 - 0 for success, -1 for error
 
-Back to [interface description](#module-vpcih).
+Back to [interface description](#interface-vpcih).
 
 ### Function `fdt_generate_vpci_node(vm, pci, fdt, gic_phandle)`
 
@@ -56,7 +56,7 @@ the virtual PCI device configuration space.
 
 - 0 for success, -1 for error
 
-Back to [interface description](#module-vpcih).
+Back to [interface description](#interface-vpcih).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_vusb.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_arm_vusb.md
@@ -40,7 +40,7 @@ Calls made to this hcd may be redirected for filtering.
 
 - A handle to the virtual usb device, or NULL on failure
 
-Back to [interface description](#module-vusbh).
+Back to [interface description](#interface-vusbh).
 
 ### Function `vm_vusb_notify(vusb)`
 
@@ -57,7 +57,7 @@ vm_install_vusb function.
 
 No return
 
-Back to [interface description](#module-vusbh).
+Back to [interface description](#interface-vusbh).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_cross_vm_connection.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_cross_vm_connection.md
@@ -50,7 +50,7 @@ PCI device
 
 - -1 on failure otherwise 0 for success
 
-Back to [interface description](#module-cross_vm_connectionh).
+Back to [interface description](#interface-cross_vm_connectionh).
 
 ### Function `consume_connection_event(vm, event_id, inject_irq)`
 
@@ -67,7 +67,7 @@ external process. The event is then relayed onto the VM.
 
 No return
 
-Back to [interface description](#module-cross_vm_connectionh).
+Back to [interface description](#interface-cross_vm_connectionh).
 
 
 ## Structs
@@ -84,7 +84,7 @@ Datastructure representing a dataport of a crossvm connection
 - `num_frames {int}`: Total number of frames in the `frames` member
 - `frames {seL4_CPtr *}`: The set of frames backing the dataport
 
-Back to [interface description](#module-cross_vm_connectionh).
+Back to [interface description](#interface-cross_vm_connectionh).
 
 ### Struct `crossvm_handle`
 
@@ -97,7 +97,7 @@ This is matched on when invoking `consume_connection_event`
 - `emit_fn {emit_fn}`: The function pointer to the crossvm emit method
 - `consume_id {seL4_Word}`: The identifier used for the crossvm connection when receiving incoming notifications
 
-Back to [interface description](#module-cross_vm_connectionh).
+Back to [interface description](#interface-cross_vm_connectionh).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_device.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_device.md
@@ -43,7 +43,7 @@ Initialise an empty device list
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-deviceh).
+Back to [interface description](#interface-deviceh).
 
 ### Function `add_device(dev_list, d)`
 
@@ -58,7 +58,7 @@ Add a generic device to a given device list without performing any initialisatio
 
 - 0 on success, otherwise -1 for error
 
-Back to [interface description](#module-deviceh).
+Back to [interface description](#interface-deviceh).
 
 ### Function `find_device_by_pa(dev_list, addr)`
 
@@ -73,7 +73,7 @@ Find a device by a given addr within a device list
 
 - Pointer to device if found, otherwise NULL if not found
 
-Back to [interface description](#module-deviceh).
+Back to [interface description](#interface-deviceh).
 
 
 ## Structs
@@ -93,7 +93,7 @@ Device Management Object
 - `handle_device_fault {int *(vm_t, vm_vcpu_t, dev, addr, len)}`: Fault handler
 - `priv {void *}`: Device emulation private data
 
-Back to [interface description](#module-deviceh).
+Back to [interface description](#interface-deviceh).
 
 ### Struct `device_list`
 
@@ -104,7 +104,7 @@ Management for a list of devices
 - `devices {struct device *}`: List of registered devices
 - `num_devices {int}`: Total number of registered devices
 
-Back to [interface description](#module-deviceh).
+Back to [interface description](#interface-deviceh).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_device_utils.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_device_utils.md
@@ -37,7 +37,7 @@ Install a passthrough device into a VM
 
 - 0 on success, -1 for error
 
-Back to [interface description](#module-device_utilsh).
+Back to [interface description](#interface-device_utilsh).
 
 ### Function `vm_install_ram_only_device(vm, device)`
 
@@ -52,7 +52,7 @@ Install a device backed by ram into a VM
 
 - 0 on success, -1 for error
 
-Back to [interface description](#module-device_utilsh).
+Back to [interface description](#interface-device_utilsh).
 
 ### Function `vm_install_listening_device(vm, device)`
 
@@ -67,7 +67,7 @@ Install a passthrough device into a VM, but trap and print all access
 
 - 0 on success, -1 for error
 
-Back to [interface description](#module-device_utilsh).
+Back to [interface description](#interface-device_utilsh).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_guest_image.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_guest_image.md
@@ -46,7 +46,7 @@ Load guest kernel image
 
 - 0 on success, otherwise -1 on error
 
-Back to [interface description](#module-guest_imageh).
+Back to [interface description](#interface-guest_imageh).
 
 ### Function `vm_load_guest_module(vm, module_name, load_address, alignment, guest_image)`
 
@@ -64,7 +64,7 @@ Load guest kernel module e.g. initrd
 
 - 0 on success, otherwise -1 on error
 
-Back to [interface description](#module-guest_imageh).
+Back to [interface description](#interface-guest_imageh).
 
 
 ## Structs
@@ -81,7 +81,7 @@ General datastructure for managing a guest image
 - `alignment {size_t}`: Alignment we used when loading the image
 - `size {size_t}`: Size of guest image
 
-Back to [interface description](#module-guest_imageh).
+Back to [interface description](#interface-guest_imageh).
 
 ### Struct `guest_kernel_image`
 
@@ -92,7 +92,7 @@ Stores information about the guest kernel image we are loading.
 - `kernel_image {guest_image_t}`: Datastructure referring to guest kernel image
 - `kernel_image_arch {guest_kernel_image_arch_t}`: Architecture specific information for loaded guest image
 
-Back to [interface description](#module-guest_imageh).
+Back to [interface description](#interface-guest_imageh).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_guest_memory_util.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_guest_memory_util.md
@@ -46,7 +46,7 @@ Create and map a reservation for a vka allocated frame. The allocated frame is m
 
 - Address of allocated frame in vmm vspace
 
-Back to [interface description](#module-guest_memory_utilh).
+Back to [interface description](#interface-guest_memory_utilh).
 
 ### Function `create_device_reservation_frame(vm, addr, rights, fault_callback, fault_cookie)`
 
@@ -64,7 +64,7 @@ Create and map a reservation for a device frame. The device frame is mapped in b
 
 - Address of device frame in vmm vspace
 
-Back to [interface description](#module-guest_memory_utilh).
+Back to [interface description](#interface-guest_memory_utilh).
 
 ### Function `map_ut_alloc_reservation_with_base_paddr(vm, paddr, reservation)`
 
@@ -80,7 +80,7 @@ Map a guest reservation backed with untyped frames allocated from a base paddr
 
 - -1 on failure otherwise 0 for success
 
-Back to [interface description](#module-guest_memory_utilh).
+Back to [interface description](#interface-guest_memory_utilh).
 
 ### Function `map_ut_alloc_reservation(vm, reservation)`
 
@@ -95,7 +95,7 @@ Map a guest reservation backed with untyped frames
 
 - -1 on failure otherwise 0 for success
 
-Back to [interface description](#module-guest_memory_utilh).
+Back to [interface description](#interface-guest_memory_utilh).
 
 ### Function `map_frame_alloc_reservation(vm, reservation)`
 
@@ -110,7 +110,7 @@ Map a guest reservation backed with free vka frames
 
 - -1 on failure otherwise 0 for success
 
-Back to [interface description](#module-guest_memory_utilh).
+Back to [interface description](#interface-guest_memory_utilh).
 
 ### Function `map_maybe_device_reservation(vm, reservation)`
 
@@ -125,7 +125,7 @@ Map a guest reservation backed with device frames
 
 - -1 on failure otherwise 0 for success
 
-Back to [interface description](#module-guest_memory_utilh).
+Back to [interface description](#interface-guest_memory_utilh).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_guest_vcpu_util.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_guest_vcpu_util.md
@@ -33,7 +33,7 @@ further intialises and configures the vcpu with platform specific attributes
 
 - NULL for error, otherwise pointer to created vm_vcpu_t object
 
-Back to [interface description](#module-guest_vcpu_utilh).
+Back to [interface description](#interface-guest_vcpu_utilh).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_ioports.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_ioports.md
@@ -52,7 +52,7 @@ This is used when registering ioport handlers of type 'IOPORT_FREE'
 
 - 0 for success, otherwise -1 for error
 
-Back to [interface description](#module-ioportsh).
+Back to [interface description](#interface-ioportsh).
 
 ### Function `vmm_io_port_add_handler(io_list, ioport_range, ioport_interface, port_type)`
 
@@ -69,7 +69,7 @@ Add an io port range for emulation
 
 - NULL for error, otherwise pointer to newly created ioport entry
 
-Back to [interface description](#module-ioportsh).
+Back to [interface description](#interface-ioportsh).
 
 ### Function `emulate_io_handler(io_port, port_no, is_in, size, data)`
 
@@ -87,7 +87,7 @@ From a set of registered ioports, emulate an io instruction given a current iopo
 
 - 0 if handled, 1 if unhandled, otherwise -1 for error
 
-Back to [interface description](#module-ioportsh).
+Back to [interface description](#interface-ioportsh).
 
 
 ## Structs
@@ -104,7 +104,7 @@ Range of ioport handler
 - `end {uint16_t}`: End address of ioport range
 - `size {uint16_t}`: Size of ioport range
 
-Back to [interface description](#module-ioportsh).
+Back to [interface description](#interface-ioportsh).
 
 ### Struct `ioport_interface`
 
@@ -117,7 +117,7 @@ Datastructure used for ioport emulation, containing handlers for the ioport rang
 - `port_out {ioport_out_fn}`: IO out operation handler
 - `desc {const char *}`: IOPort description, useful for debugging
 
-Back to [interface description](#module-ioportsh).
+Back to [interface description](#interface-ioportsh).
 
 ### Struct `ioport_entry`
 
@@ -128,7 +128,7 @@ Datastructure used to present a registered ioport range
 - `range {ioport_range_t}`: IO address range of ioport entry
 - `interface {ioport_interface_t}`: Emulation interface for ioport range
 
-Back to [interface description](#module-ioportsh).
+Back to [interface description](#interface-ioportsh).
 
 ### Struct `vmm_io_list`
 
@@ -140,7 +140,7 @@ Parent datastructure used to maintain a list of registered ioports
 - `List {ioport_entry_t **}`: of registered ioport objects
 - `alloc_addr {uint16_t}`: Base ioport address we can safely bump allocate from, used when registering ioport handlers of type 'IOPORT_FREE'
 
-Back to [interface description](#module-ioportsh).
+Back to [interface description](#interface-ioportsh).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_pci.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_pci.md
@@ -48,7 +48,7 @@ Initialize PCI space
 
 - 0 on success, -1 on error
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Function `vmm_pci_add_entry(space, entry, addr)`
 
@@ -64,7 +64,7 @@ Add a PCI entry. Optionally reports where it is located
 
 - 0 on success, -1 on error
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Function `make_addr_reg_from_config(conf, addr, reg)`
 
@@ -80,7 +80,7 @@ Convert config to pci address
 
 No return
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Function `find_device(self, addr)`
 
@@ -95,7 +95,7 @@ Find PCI device given a PCI address (Bus/Dev/Func)
 
 - NULL on error, otherwise pointer to registered pci entry
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 
 ## Structs
@@ -112,7 +112,7 @@ Represents a PCI address by Bus/Device/Function
 - `dev {uint8_t}`: Device value
 - `fun {uint8_t}`: Function value
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Struct `vmm_pci_entry`
 
@@ -124,7 +124,7 @@ Abstracts the virtual PCI device. This is is inserted into the virtual PCI confi
 - `ioread {int *(void *cookie, int offset, int size, uint32_t *result)}`: Configuration space read callback
 - `iowrite {int *(void *cookie, int offset, int size, uint32_t value)}`: Configuration space write callback
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Struct `vmm_pci_sapce`
 
@@ -136,7 +136,7 @@ Represents a single host virtual PCI space
 - `bus {vmm_pci_entry_t *}`: The PCI bus, representing 32 devices, each of which has 8 functions
 - `conf_port_addr {uint32_t}`: The current config address for IO port emulation
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_pci_helper.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_pci_helper.md
@@ -65,7 +65,7 @@ Helper write function that just ignores any writes
 
 - Returns 0
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Function `vmm_pci_mem_device_read(cookie, offset, size, result)`
 
@@ -82,7 +82,7 @@ Read method for a PCI devices memory
 
 - 0 if success, -1 if error
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Function `vmm_pci_mem_device_write(cookie, offset, size, value)`
 
@@ -99,7 +99,7 @@ Write method for a PCI devices memory
 
 - 0 if success, -1 if error
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Function `define_pci_host_bridge(bridge)`
 
@@ -113,7 +113,7 @@ Defines the configuration space values of the PCI host bridge
 
 No return
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Function `vmm_pci_create_passthrough(addr, config)`
 
@@ -129,7 +129,7 @@ you will almost certainly want to rebase io memory
 
 - `vmm_pci_entry_t` for passthrough device
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Function `vmm_pci_create_bar_emulation(existing, num_bars, bars)`
 
@@ -145,7 +145,7 @@ Construct a pci entry that emulates configuration space bar read/write's. The re
 
 - `vmm_pci_entry_t` for emulated bar device
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Function `vmm_pci_create_irq_emulation(existing, irq)`
 
@@ -160,7 +160,7 @@ Construct a pci entry the emulates configuration space interrupt read/write's. T
 
 - `vmm_pci_entry_t` for emulated irq device
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Function `vmm_pci_create_cap_emulation(existing, num_caps, cap, num_ranges, range_starts, range_ends)`
 
@@ -180,7 +180,7 @@ ranges of the capability space that should be directly disallowed. Assumes a typ
 
 - `vmm_pci_entry_t` with an emulated capability space
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 
 ## Structs
@@ -228,7 +228,7 @@ a nice skeleton
 - `caps_len {int}`
 - `caps {void *}`
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Struct `vmm_pci_bar`
 
@@ -240,7 +240,7 @@ Represents a PCI bar within a device
 - `address {uintptr_t}`: Address of PCI bar
 - `size_bits {size_t}`: Size of PCI bar in bits
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Struct `pci_bar_emulation`
 
@@ -255,7 +255,7 @@ the guest OS over-writing elements in the configuration space
 - `bars {vmm_pci_bar_t}`: Set of PCI bars being emulated in the PCI entry
 - `bar_writes {uint32_t}`: Most recent write to each PCI bar in the configuration space. This avoids
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Struct `pci_irq_emulation`
 
@@ -267,7 +267,7 @@ IRQ line accesses in an entries configuration space
 - `passthrough {vmm_pci_entry_t}`: PCI entry being emulated
 - `irq {int}`: IRQ line value in PCI entry
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Struct `pci_passthrough_device`
 
@@ -278,7 +278,7 @@ Datastructure providing direct passthrough access to a pci entry configuration s
 - `addr {vmm_pci_address_t}`: Address of PCI device
 - `config {vmm_pci_config_t}`: Ops for accessing config space
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 ### Struct `pci_cap_emulation`
 
@@ -294,7 +294,7 @@ capabilities in an entries configuration space.
 - `ignore_start {uint8_t *}`: Array of starting indexes of ignored capability ranges
 - `ignore_end {uint8_t *}`: Array of ending idexes of ignored capabilities range
 
-Back to [interface description](#module-pcih).
+Back to [interface description](#interface-pcih).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_virtio_con.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_virtio_con.md
@@ -47,7 +47,7 @@ virtio_con_default_backend for default methods.
 
 - Pointer to an initialised virtio_con_t, NULL if error.
 
-Back to [interface description](#module-virtio_conh).
+Back to [interface description](#interface-virtio_conh).
 
 
 ## Structs
@@ -65,7 +65,7 @@ Virtio Console Driver Interface
 - `emul_driver_funcs {struct console_passthrough}`: Virtio console emulation functions: VMM <-> Guest
 - `ioops {ps_io_ops_t}`: Platform support io ops datastructure
 
-Back to [interface description](#module-virtio_conh).
+Back to [interface description](#interface-virtio_conh).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_virtio_net.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_virtio_net.md
@@ -50,7 +50,7 @@ virtio_net_default_backend for default methods.
 
 - Pointer to an initialised virtio_net_t, NULL if error.
 
-Back to [interface description](#module-virtio_neth).
+Back to [interface description](#interface-virtio_neth).
 
 ### Function `virtio_net_default_backend()`
 
@@ -64,7 +64,7 @@ No parameters
 
 - A struct with a default virtio_net backend. It is the responsibility of the caller to
 
-Back to [interface description](#module-virtio_neth).
+Back to [interface description](#interface-virtio_neth).
 
 
 ## Structs
@@ -83,7 +83,7 @@ Virtio Net Driver Interface
 - `emul_driver_funcs {struct raw_iface_funcs}`: Virtio Ethernet emulation functions: VMM <-> Guest
 - `ioops {ps_io_ops_t}`: Platform support ioops for dma management
 
-Back to [interface description](#module-virtio_neth).
+Back to [interface description](#interface-virtio_neth).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_x86_acpi.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_x86_acpi.md
@@ -32,7 +32,7 @@ Creates ACPI table for the guest VM
 
 - 0 for success, -1 for error
 
-Back to [interface description](#module-acpih).
+Back to [interface description](#interface-acpih).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_x86_guest_boot_init.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_x86_guest_boot_init.md
@@ -40,7 +40,7 @@ boot info structure, an e820 map and ACPI tables.
 
 - 0 for success, -1 for error
 
-Back to [interface description](#module-guest_boot_inith).
+Back to [interface description](#interface-guest_boot_inith).
 
 ### Function `vmm_plat_init_guest_thread_state(vcpu, guest_entry_addr, guest_boot_info_addr)`
 
@@ -56,7 +56,7 @@ Initialise the booting state of a guest VM, establishing the necessary thread st
 
 - 0 for success, -1 for error
 
-Back to [interface description](#module-guest_boot_inith).
+Back to [interface description](#interface-guest_boot_inith).
 
 
 Back to [top](#).

--- a/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_x86_vmm_pci_helper.md
+++ b/libsel4vmmplatsupport/docs/libsel4vmmplatsupport_x86_vmm_pci_helper.md
@@ -38,7 +38,7 @@ PCI device. This will map MMIO and IO-based bars.
 
 - -1 for error, otherwise the number of bars mapped into the VM (>=0)
 
-Back to [interface description](#module-vmm_pci_helperh).
+Back to [interface description](#interface-vmm_pci_helperh).
 
 ### Function `vmm_pci_io_port_in(vcpu, cookie, port_no, size, result)`
 
@@ -55,7 +55,7 @@ Emulates IOPort in access on the VMM Virtual PCI device
 
 No return
 
-Back to [interface description](#module-vmm_pci_helperh).
+Back to [interface description](#interface-vmm_pci_helperh).
 
 ### Function `vmm_pci_io_port_out(vcpu, cookie, port_no, size, value)`
 
@@ -72,7 +72,7 @@ Emulates IOPort out access on the VMM Virtual PCI device
 
 No return
 
-Back to [interface description](#module-vmm_pci_helperh).
+Back to [interface description](#interface-vmm_pci_helperh).
 
 
 Back to [top](#).


### PR DESCRIPTION
The anchors are called #interface-*, not #module-*. Not sure which one changed from the generated version, but since we are maintaining the result manually, apply the fix to the links directly.